### PR TITLE
Set TLS 1.2 based on .NET version

### DIFF
--- a/Public/oauth2.ps1
+++ b/Public/oauth2.ps1
@@ -87,8 +87,8 @@ function Request-FalconToken {
                         $Script:Falcon.Api.Handler.SslProtocols = 'Tls12'
                         Write-Verbose "[Request-FalconToken] Set TLS 1.2 via [System.Net.Http.HttpClientHandler]"
                     } catch {
-                        # Set TLS 1.2 for PowerShell session if not set already
                         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
+                            # Set TLS 1.2 for PowerShell session
                             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                             Write-Verbose "[Request-FalconToken] Set TLS 1.2 via [Net.ServicePointManager]"
                         }

--- a/Public/oauth2.ps1
+++ b/Public/oauth2.ps1
@@ -82,13 +82,16 @@ function Request-FalconToken {
                 $Script:Falcon = Get-ApiCredential $PSBoundParameters
                 $Script:Falcon.Add('Api', [ApiClient]::New())
                 if ($Script:Falcon.Api) {
-                    if ($Script:Falcon.Api.Handler.PSObject.Members | Where-Object { $_.MemberType -eq
-                    'Property' -and $_.Name -eq 'SslProtocols' }) {
-                        # Set 'SslProtocols' for Handler
+                    try {
+                        # Set TLS 1.2 for [System.Net.Http.HttpClientHandler]
                         $Script:Falcon.Api.Handler.SslProtocols = 'Tls12'
-                    } elseif ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-                        # Set TLS 1.2 for PowerShell session
-                        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+                        Write-Verbose "[Request-FalconToken] Set TLS 1.2 via [System.Net.Http.HttpClientHandler]"
+                    } catch {
+                        # Set TLS 1.2 for PowerShell session if not set already
+                        if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
+                            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+                            Write-Verbose "[Request-FalconToken] Set TLS 1.2 via [Net.ServicePointManager]"
+                        }
                     }
                     $Script:Falcon.Api.Handler.AutomaticDecompression = [System.Net.DecompressionMethods]::Gzip,
                         [System.Net.DecompressionMethods]::Deflate


### PR DESCRIPTION
## Set TLS 1.2 based on .NET version
Issue #154: Added try/catch to set TLS 1.2 via 'SslProtocols' property in [System.Net.Http.HttpClientHandler]. If that fails, TLS 1.2. is set for the PowerShell session via [Net.ServicePointManager] if not set already.

- [x] Bug fixes

## Issues resolved
* Fixes https://github.com/CrowdStrike/psfalcon/issues/154 by adhering to the differences in .NET versions for TLS 1.2 enforcement 