### PR TITLE
Allow self-hosted Humio instances for psf-humio

### DIFF
--- a/Public/psf-humio.ps1
+++ b/Public/psf-humio.ps1
@@ -65,8 +65,7 @@ function Send-FalconEvent {
                 $_.PSObject.Properties | Where-Object { $_.Name -notmatch '\.' } | ForEach-Object {
                     $Item.attributes[$_.Name] = $_.Value
                 }
-            }
-            elseif ($_ -is [string]) {
+            } elseif ($_ -is [string]) {
                 $Item.attributes['id'] = $_
             }
             $Item


### PR DESCRIPTION
# Changed Register-FalconEventCollector's Uri parameter to support self-hosted Humio clusters.

Simply changed the Uri parameter in Register-FalconEventCollector from ValidateSet to ArgumentCompletions as ValidateSet enforces values and not allowing me to use PSFalcon to ingest into my own Humio cluster.

- [X] Enhancement

## Added features and functionality
+ Register-FalconEventCollector now supports self-hosted Humio clusters