### PR TITLE
Restructured file and added Class.ps1 to imports

### DIFF
--- a/PSFalcon.psm1
+++ b/PSFalcon.psm1
@@ -1,10 +1,15 @@
 # Import public and private functions
-$Public = Get-ChildItem -Path $PSScriptRoot\Public\*.ps1
-$Private = Get-ChildItem -Path $PSScriptRoot\Private\Private.ps1
-@($Public + $Private).foreach{
+$imports = @(
+    Get-ChildItem -Path $PSScriptRoot\Public\*.ps1
+    Get-ChildItem -Path $PSScriptRoot\Private\Private.ps1
+    Get-ChildItem -Path $PSScriptRoot\Class\Class.ps1
+)
+
+$imports.foreach{
     try {
         . $_.FullName
-    } catch {
+    }
+    catch {
         throw $_
     }
 }


### PR DESCRIPTION
## Restructured file and added Class.ps1 to imports
When importing the PSM only, you'd get an error whilst executing Request-FalconToken due to missing the class you only get from PSD file.

Restructured the way of imports for visibility and added the Class.ps1.

I looked around for solutions and stumbled upon a PR [[1]](#1) from PowerShell saying that for development scenarios that psm importing is allowed, therefore I find this that "right" way of correcting this.

- [X] Enhancement
- [ ] Breaking Change <- I do not know, but wouldn't assume!

## References
+ <a id="1">[1]</a> [Import-Module foo.psm1 should still process foo.psd1 if exists](https://github.com/PowerShell/PowerShell/issues/7464#issuecomment-490682420)
