### PR TITLE
Added support for MemberCid with CCID

### DIFF
--- a/Public/oauth2.ps1
+++ b/Public/oauth2.ps1
@@ -25,7 +25,7 @@ function Request-FalconToken {
         [Parameter(ParameterSetName = 'Cloud', ValueFromPipelineByPropertyName = $true, Position = 4)]
         [Parameter(ParameterSetName = 'Hostname', ValueFromPipelineByPropertyName = $true, Position = 4)]
         [Alias('cid', 'member_cid')]
-        [ValidatePattern('^\w{32}$')]
+        [ValidatePattern('^\w{32}(-\w{2})?$')]
         [string] $MemberCid,
 
         [Parameter(ParameterSetName = 'Cloud', ValueFromPipelineByPropertyName = $true, Position = 5)]
@@ -41,6 +41,9 @@ function Request-FalconToken {
         [System.Collections.Hashtable] $Collector
     )
     begin {
+        if ($MemberCid -match '^\w{32}-\w{2}$'){
+            $PSBoundParameters.MemberCid = $MemberCid.Split('-')[0]
+        }
         function Get-ApiCredential ($Inputs) {
             $Output = @{}
             @('ClientId', 'ClientSecret', 'Hostname', 'MemberCid').foreach{


### PR DESCRIPTION
## Added support for MemberCid with CCID
Using CID from 'Sensor Download' section for easy copy/paste, this includes the Checksum of the CID (CCID), eg. `13AEC47406HS467AC2E2AC393CD02784-A0`.

This normally causes an error due to pattern validation, Simply allowing the format and stripping the checksum. Before this enhancement you'd encounter an error like below.
```Request-FalconToken : Cannot validate argument on parameter 'MemberCid'. The argument "[REMOVED CID]" does not match the "^\w{32}$" pattern. Supply an argument that matches "^\w{32}$" and try the command again.```

- [X] Enhancement

## Added features and functionality
+ Support for MemberCid with CCID format
