### PR TITLE
Bugfix CrowdStrike/psfalcon#260

### DIFF
--- a/Public/policy-ioa-exclusions.ps1
+++ b/Public/policy-ioa-exclusions.ps1
@@ -25,13 +25,13 @@ https://github.com/crowdstrike/psfalcon/wiki/ConvertTo-FalconIoaExclusion
 #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,ValueFromPipeline,Position=1)]
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)]
         [System.Object]$Detection
     )
     begin { [System.Collections.Generic.List[object]]$Output = @() }
     process {
-        if ($_.behaviors -and $_.device) {
-            @($_.behaviors).Where({ $_.tactic -notmatch '^(Machine Learning|Malware)$' }).foreach{
+        if ($Detection.behaviors -and $Detection.device) {
+            @($Detection.behaviors).Where({ $_.tactic -notmatch '^(Machine Learning|Malware)$' }).foreach{
                 $Output.Add(([PSCustomObject]@{
                     pattern_id = $_.behavior_id
                     pattern_name = $_.display_name
@@ -43,8 +43,8 @@ https://github.com/crowdstrike/psfalcon/wiki/ConvertTo-FalconIoaExclusion
             }
         } else {
             foreach ($Property in @('behaviors','device')) {
-                if (!$_.$Property) {
-                    throw "[ConvertTo-FalconMlExclusion] Missing required '$Property' property."
+                if (!$Detection.$Property) {
+                    throw "[ConvertTo-FalconIoaExclusion] Missing required '$Property' property."
                 }
             }
         }


### PR DESCRIPTION
## Bugfix CrowdStrike/psfalcon#260

- [X] Bug fixes 

### Issue Title
[ BUG ] `ConvertTo-FalconIoaExclusion` throws an error stating behaviors property is missing when it isn't.

### Details
The `ConvertTo-FalconIoaExclusion` only works when passing detections via pipeline input, but not via explicit parameter.

Works:
```powershell
$MyDetection | ConvertTo-FalconIoaExclusion
```

Does not work:
```powershell
ConvertTo-FalconIoaExclusion -Detection $MyDetection
```

## Issues resolved
* Fixes CrowdStrike/psfalcon#260 by using parameter name `$Detection` instead of implied `$_` in `Process` block.
* Fixes copy/paste typo in `throw` statement referencing `FalconMlExclusion` vice `FalconIoaExclusion`

## Other
```
The following changes since commit 2d73687da2af710c8080e6482d631af50566dd4b:

  Merge pull request #250 from CrowdStrike/2.2.3 (2022-10-31 13:51:27 -0700)

are available in the Git repository at:

  https://github.com/datorr2/psfalcon.git

for you to fetch changes up to 22e50f1d3f84f5558678d8f36c4d2872a0eec4e5:

  Bugfix CrowdStrike/psfalcon#260 (2022-12-08 21:06:18 -0500)

----------------------------------------------------------------
Damian Torres (1):
      Bugfix CrowdStrike/psfalcon#260

 Public/policy-ioa-exclusions.ps1 | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)

diff --git a/Public/policy-ioa-exclusions.ps1 b/Public/policy-ioa-exclusions.ps1
index 22cf5ce..dd16e89 100644
--- a/Public/policy-ioa-exclusions.ps1
+++ b/Public/policy-ioa-exclusions.ps1
@@ -25,13 +25,13 @@ https://github.com/crowdstrike/psfalcon/wiki/ConvertTo-FalconIoaExclusion
 #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,ValueFromPipeline,Position=1)]
+        [Parameter(Mandatory,ValueFromPipeline,Position=0)]
         [System.Object]$Detection
     )
     begin { [System.Collections.Generic.List[object]]$Output = @() }
     process {
-        if ($_.behaviors -and $_.device) {
-            @($_.behaviors).Where({ $_.tactic -notmatch '^(Machine Learning|Malware)$' }).foreach{
+        if ($Detection.behaviors -and $Detection.device) {
+            @($Detection.behaviors).Where({ $_.tactic -notmatch '^(Machine Learning|Malware)$' }).foreach{
                 $Output.Add(([PSCustomObject]@{
                     pattern_id = $_.behavior_id
                     pattern_name = $_.display_name
@@ -43,8 +43,8 @@ https://github.com/crowdstrike/psfalcon/wiki/ConvertTo-FalconIoaExclusion
             }
         } else {
             foreach ($Property in @('behaviors','device')) {
-                if (!$_.$Property) {
-                    throw "[ConvertTo-FalconMlExclusion] Missing required '$Property' property."
+                if (!$Detection.$Property) {
+                    throw "[ConvertTo-FalconIoaExclusion] Missing required '$Property' property."
                 }
             }
         }
@@ -315,4 +315,4 @@ https://github.com/crowdstrike/psfalcon/wiki/Remove-FalconIoaExclusion
             Invoke-Falcon @Param -Inputs $PSBoundParameters
         }
     }
-}
\ No newline at end of file
+}
```