### PR TITLE
[ BUG ] Mismatching execution languages in `Invoke-FalconDeploy`

### DIFF
--- a/public/psf-real-time-response.ps1
+++ b/public/psf-real-time-response.ps1
@@ -456,21 +456,22 @@ https://github.com/crowdstrike/psfalcon/wiki/Invoke-FalconDeploy
                                             if ($Pair.Key -eq 'Windows') {
                                                 # Use 'runscript' to start process and avoid timeout
                                                 [string]$String = if ($Argument) {
-                                                    "Set-Location $TempDir;$($TempDir,$RunFile -join $Join)",
+                                                     "Set-Location $TempDir;$(Join-Path -Path $TempDir -ChildPath $RunFile)",
                                                         $Argument -join ' '
                                                 } else {
-                                                    "Set-Location $TempDir;$($TempDir,$RunFile -join $Join)"
+                                                     "Set-Location $TempDir;$(Join-Path -Path $TempDir -ChildPath $RunFile)"
                                                 }
-                                                [string]$Executable = if ($RunFile -match '\.cmd$') {
-                                                    'cmd',"'/c $String'" -join ' '
+                                                Write-verbose "$String"
+
+                                                [string]$Executable = if ( ($RunFile -match '\.cmd$') -or ($RunFile -match '\.bat$' )) {
+                                                    "cmd.exe /c cd /d `"$TempDir`" && `"$RunFile`" $Argument"
                                                 } else {
-                                                    'powershell.exe',"'-c &{$String}'" -join ' '
+                                                    'powershell.exe',"' -NoProfile  -WindowStyle hidden -NoLogo -NonInteractive -ExecutionPolicy Bypass -c &{$String}'" -join ' '
                                                 }
                                                 '-Raw=```Start-Process',$Executable,
-                                                "-RedirectStandardOutput '$($TempDir,'stdout.log' -join $Join)'",
-                                                "-RedirectStandardError '$($TempDir,'stderr.log' -join $Join)'",
-                                                ('-PassThru | ForEach-Object { "The process was successfully sta' +
-                                                'rted"'),'}```' -join ' '
+                                                "-RedirectStandardOutput '$(Join-Path -Path $TempDir -ChildPath stdout.log)'",
+                                                "-RedirectStandardError '$(Join-Path -Path $TempDir -ChildPath stderr.log)'",
+                                                ('-PassThru | ForEach-Object { "The process was successfully started"'),'}```' -join ' '
                                             } elseif ($Pair.Key -match '^(Linux|Mac)$') {
                                                 # Use 'runscript' to start background process and avoid timeout
                                                 [string]$String = if ($Argument) {


### PR DESCRIPTION
Fixes #327

## Correct Code for batch (CMD and BAT)  lines
Correct Code for batch (CMD and BAT) Lines

- [X] Enhancement : added powershell "ExecutionPolicy Bypass"
- [X] Bug fixes : Removed powershell commands from Command line.

## Added features and functionality
+ For powershell commandline added "-NoProfile  -WindowStyle hidden -NoLogo -NonInteractive -ExecutionPolicy Bypass"

## Issues resolved
* Fixes https://github.com/CrowdStrike/psfalcon/issues/327 by using correct syntax.

