### PR TITLE
Request-FalconRegistryCredential: fix the pull scope

### DIFF
--- a/public/container-security.ps1
+++ b/public/container-security.ps1
@@ -357,7 +357,7 @@ https://github.com/crowdstrike/psfalcon/wiki/Request-FalconRegistryCredential
         'us-2'    { 'us-2' }
         default     { 'us-1' }
       }
-      $PSBoundParameters['scope'] = 'repository:',"/$Region/release/",':pull' -join
+      $PSBoundParameters['scope'] = 'repository:',"/$Region/release/falcon-sensor:pull" -join
         $PSBoundParameters.SensorType
       $PSBoundParameters['service'] = 'registry.crowdstrike.com'
       [void]$PSBoundParameters.Remove('SensorType')


### PR DESCRIPTION
No Matter the SensorType, the repo name is always `falcon-sensor`
- [ ] Enhancement
- [ ] Major Feature update
- [X] Bug fixes 
- [ ] Breaking Change
- [ ] Documentation

## Issues resolved
* Fixes Registry scope request
