### PR TITLE
Enhancement : add temporary roles possibility to Add-FalconRole module

### DIFF
--- a/format/format.json
+++ b/format/format.json
@@ -1,5735 +1,5736 @@
 {
-  "/alerts/entities/alerts/v2": {
-    "post": {
-      "body": {
-        "root": [
-          "composite_ids"
-        ]
-      },
-      "query": [
-        "include_hidden"
-      ]
+    "/alerts/entities/alerts/v2": {
+        "post": {
+            "body": {
+                "root": [
+                    "composite_ids"
+                ]
+            },
+            "query": [
+                "include_hidden"
+            ]
+        }
+    },
+    "/alerts/entities/alerts/v3": {
+        "patch": {
+            "body": {
+                "action_parameters": [
+                    "name",
+                    "value"
+                ],
+                "root": [
+                    "composite_ids"
+                ]
+            },
+            "query": [
+                "include_hidden"
+            ]
+        }
+    },
+    "/alerts/queries/alerts/v2": {
+        "get": {
+            "query": [
+                "include_hidden",
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/archives/entities/archive-files/v1": {
+        "get": {
+            "query": [
+                "id",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/archives/entities/archives/v1": {
+        "get": {
+            "query": [
+                "id",
+                "include_files"
+            ]
+        },
+        "delete": {
+            "query": [
+                "id"
+            ]
+        }
+    },
+    "/archives/entities/archives/v2": {
+        "post": {
+            "formdata": [
+                "file",
+                "password",
+                "name",
+                "is_confidential",
+                "comment"
+            ]
+        }
+    },
+    "/archives/entities/extraction-files/v1": {
+        "get": {
+            "query": [
+                "id",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/archives/entities/extractions/v1": {
+        "get": {
+            "query": [
+                "id",
+                "include_files"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "extract_all",
+                    "sha256"
+                ],
+                "files": [
+                    "comment",
+                    "is_confidential",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/billing-dashboards-usage/aggregates/weekly-average/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-aws/entities/account/v1": {
+        "get": {
+            "query": [
+                "scan-type",
+                "ids",
+                "iam_role_arns",
+                "organization-ids",
+                "status",
+                "limit",
+                "cspm_lite",
+                "migrated",
+                "offset",
+                "group_by"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "account_id",
+                    "account_type",
+                    "behavior_assessment_enabled",
+                    "cloudtrail_region",
+                    "dspm_enabled",
+                    "dspm_role",
+                    "iam_role_arn",
+                    "is_master",
+                    "organization_id",
+                    "sensor_management_enabled",
+                    "target_ous",
+                    "use_existing_cloudtrail"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "organization-ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "account_id",
+                    "behavior_assessment_enabled",
+                    "cloudtrail_region",
+                    "dspm_enabled",
+                    "dspm_role",
+                    "environment",
+                    "iam_role_arn",
+                    "remediation_region",
+                    "remediation_tou_accepted",
+                    "sensor_management_enabled",
+                    "target_ous"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-aws/entities/user-scripts-download/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "template",
+                "account_type",
+                "accounts",
+                "behavior_assessment_enabled",
+                "sensor_management_enabled",
+                "dspm_enabled",
+                "dspm_regions",
+                "dspm_role",
+                "use_existing_cloudtrail",
+                "organization_id",
+                "aws_profile",
+                "custom_role_name"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-azure/entities/account/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "tenant_ids",
+                "scan-type",
+                "status",
+                "cspm_lite",
+                "limit",
+                "offset"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "account_type",
+                    "client_id",
+                    "default_subscription",
+                    "subscription_id",
+                    "tenant_id",
+                    "years_valid"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "tenant_ids",
+                "retain_tenant"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-azure/entities/client-id/v1": {
+        "patch": {
+            "query": [
+                "id",
+                "tenant-id"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-azure/entities/default-subscription-id/v1": {
+        "patch": {
+            "query": [
+                "tenant-id",
+                "subscription_id"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-azure/entities/download-certificate/v1": {
+        "get": {
+            "query": [
+                "tenant_id",
+                "refresh",
+                "years_valid"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-azure/entities/management-group/v1": {
+        "delete": {
+            "query": [
+                "tenant_ids"
+            ]
+        },
+        "get": {
+            "query": [
+                "tenant_ids",
+                "limit",
+                "offset"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "default_subscription_id",
+                    "tenant_id"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-azure/entities/user-scripts-download/v1": {
+        "get": {
+            "query": [
+                "tenant-id",
+                "subscription_ids",
+                "account_type",
+                "template",
+                "azure_management_group"
+            ]
+        }
+    },
+    "/cloud-connect-cspm-gcp/entities/account/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "get": {
+            "query": [
+                "parent_type",
+                "ids",
+                "scan-type",
+                "status",
+                "limit",
+                "offset",
+                "sort"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "environment",
+                    "parent_id",
+                    "service_account"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-gcp/entities/account/v2": {
+        "post": {
+            "body": {
+                "resources": [
+                    "client_email",
+                    "client_id",
+                    "parent_id",
+                    "parent_type",
+                    "private_key",
+                    "private_key_id",
+                    "project_id",
+                    "service_account_conditions",
+                    "service_account_id"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-gcp/entities/account/validate/v1": {
+        "post": {
+            "body": {
+                "resources": [
+                    "parent_id"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-gcp/entities/service-accounts/v1": {
+        "get": {
+            "query": [
+                "id"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "client_email",
+                    "client_id",
+                    "private_key",
+                    "private_key_id",
+                    "project_id",
+                    "service_account_conditions",
+                    "service_account_id"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-gcp/entities/service-accounts/validate/v1": {
+        "post": {
+            "body": {
+                "resources": [
+                    "client_email",
+                    "client_id",
+                    "private_key",
+                    "private_key_id",
+                    "project_id",
+                    "service_account_conditions",
+                    "service_account_id"
+                ]
+            }
+        }
+    },
+    "/cloud-connect-cspm-gcp/entities/user-scripts-download/v1": {
+        "get": {
+            "query": [
+                "parent_type",
+                "ids"
+            ]
+        }
+    },
+    "/configuration-assessment/combined/assessments/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter",
+                "facet"
+            ]
+        }
+    },
+    "/configuration-assessment/entities/evaluation-logic/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/configuration-assessment/entities/rule-details/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/compliance-by-clusters/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/compliance-by-rules/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-containers-by-rules/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-containers-count-by-severity/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-images-by-rules/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-images-count-by-severity/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-rules-by-clusters/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-rules-by-images/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/failed-rules-count-by-severity/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-compliance/aggregates/rules-by-status/v2": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/clusters/count-by-date/v1": {
+        "get": {}
+    },
+    "/container-security/aggregates/clusters/count-by-kubernetes-version/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/clusters/count-by-status/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/clusters/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/container-alerts/count-by-severity/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/container-alerts/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/count-by-date/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/count-by-registry/v1": {
+        "get": {
+            "query": [
+                "under_assessment",
+                "limit"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/count-by-zero-day/v1": {
+        "get": {}
+    },
+    "/container-security/aggregates/containers/count-vulnerable-images/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/find-by-runtimeversion/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "offset",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/group-by-managed/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/image-detections-count-by-date/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/images-by-state/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/sensor-coverage/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/containers/vulnerability-count-by-severity/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/deployments/count-by-date/v1": {
+        "get": {}
+    },
+    "/container-security/aggregates/deployments/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/detections/count-by-severity/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/detections/count-by-type/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/detections/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/drift-indicators/count-by-date/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit"
+            ]
+        }
+    },
+    "/container-security/aggregates/drift-indicators/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/images/assessment-history/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/images/count-by-distinct/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/images/count-by-os-distribution/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/images/count-by-state/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/images/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/images/most-used/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/kubernetes-ioms/count-by-date/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/kubernetes-ioms/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/namespaces/count-by-date/v1": {
+        "get": {}
+    },
+    "/container-security/aggregates/namespaces/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/nodes/count-by-cloud/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/nodes/count-by-container-engine-version/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/nodes/count-by-date/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/nodes/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/packages/count-by-zero-day/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/pods/count-by-date/v1": {
+        "get": {}
+    },
+    "/container-security/aggregates/pods/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/unidentified-containers/count-by-date/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/unidentified-containers/count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/container-security/aggregates/vulnerabilities/count-by-actively-exploited/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/aggregates/vulnerabilities/count-by-cps-rating/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/aggregates/vulnerabilities/count-by-cvss-score/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/aggregates/vulnerabilities/count-by-severity/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/aggregates/vulnerabilities/count/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/clusters/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/container-alerts/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset",
+                "sort"
+            ]
+        }
+    },
+    "/container-security/combined/container-images/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/containers/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/deployments/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/detections/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/drift-indicators/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/image-assessment/images/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/images/detail/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "with_config",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/kubernetes-ioms/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/nodes/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/packages/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "only_zero_day_affected",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/pods/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/combined/vulnerabilities/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset",
+                "sort"
+            ]
+        }
+    },
+    "/container-security/combined/vulnerabilities/info/v1": {
+        "get": {
+            "query": [
+                "cve_id",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/entities/base-images/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "base_images": [
+                    "image_digest",
+                    "image_id",
+                    "registry",
+                    "repository",
+                    "tag"
+                ]
+            }
+        }
+    },
+    "/container-security/entities/drift-indicators/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/container-security/entities/image-assessment-policies/v1": {
+        "delete": {
+            "query": [
+                "id"
+            ]
+        },
+        "get": {},
+        "post": {
+            "body": {
+                "root": [
+                    "description",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/container-security/entities/image-assessment-policy-exclusions/v1": {
+        "get": {}
+    },
+    "/container-security/entities/image-assessment-policy-groups/v1": {
+        "delete": {
+            "query": [
+                "id"
+            ]
+        },
+        "get": {}
+    },
+    "/container-security/entities/image-assessment-policy-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "precedence"
+                ]
+            }
+        }
+    },
+    "/container-security/entities/kubernetes-ioms/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/container-security/entities/registries/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/container-security/queries/detections/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/queries/drift-indicators/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/queries/kubernetes-ioms/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/container-security/queries/registries/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "offset",
+                "sort"
+            ]
+        }
+    },
+    "/correlation-rules/combined/rules/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "q",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/correlation-rules/entities/rules/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/correlation-rules/queries/rules/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "q",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/delivery-settings/entities/delivery-settings/v1": {
+        "get": {},
+        "post": {
+            "body": {
+                "delivery_settings": [
+                    "delivery_cadence",
+                    "delivery_type"
+                ]
+            }
+        }
+    },
+    "/detects/entities/detects/v2": {
+        "patch": {
+            "body": {
+                "root": [
+                    "assigned_to_uuid",
+                    "comment",
+                    "ids",
+                    "new_behaviors_processed",
+                    "show_in_ui",
+                    "status"
+                ]
+            }
+        }
+    },
+    "/detects/entities/ioa/v1": {
+        "get": {
+            "query": [
+                "cloud_provider",
+                "service",
+                "account_id",
+                "aws_account_id",
+                "azure_subscription_id",
+                "azure_tenant_id",
+                "state",
+                "date_time_since",
+                "since",
+                "severity",
+                "next_token",
+                "limit",
+                "resource_id",
+                "resource_uuid"
+            ]
+        }
+    },
+    "/detects/entities/iom/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/detects/entities/summaries/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/detects/queries/detects/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/detects/queries/iom/v2": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset",
+                "next_token"
+            ]
+        }
+    },
+    "/devices/combined/devices/login-history/v2": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/devices/combined/devices/network-address-history/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/devices/combined/host-group-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/devices/combined/host-groups/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/devices/entities/devices-actions/v2": {
+        "post": {
+            "body": {
+                "action_parameters": [
+                    "name",
+                    "value"
+                ],
+                "root": [
+                    "ids"
+                ]
+            },
+            "query": [
+                "action_name"
+            ]
+        }
+    },
+    "/devices/entities/devices/tags/v1": {
+        "patch": {
+            "body": {
+                "root": [
+                    "action",
+                    "device_ids",
+                    "tags"
+                ]
+            }
+        }
+    },
+    "/devices/entities/devices/v2": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/devices/entities/host-groups/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "assignment_rule",
+                    "description",
+                    "group_type",
+                    "name"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "assignment_rule",
+                    "description",
+                    "id",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/devices/entities/online-state/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/devices/queries/devices-hidden/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/devices/queries/devices-scroll/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/devices/queries/host-group-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/devices/queries/host-groups/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/device-content/entities/states/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/device-content/queries/states/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "offset",
+                "filter"
+            ]
+        }
+    },
+    "/discover/combined/applications/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter",
+                "facet"
+            ]
+        }
+    },
+    "/discover/combined/hosts/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter",
+                "facet"
+            ]
+        }
+    },
+    "/discover/entities/accounts/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/discover/entities/applications/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/discover/entities/hosts/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/discover/entities/iot-hosts/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/discover/entities/logins/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/discover/queries/accounts/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/discover/queries/applications/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/discover/queries/hosts/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/discover/queries/iot-hosts/v2": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/discover/queries/logins/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/enrollments/entities/details/v4": {
+        "post": {
+            "body": {
+                "root": [
+                    "email_addresses",
+                    "enrollment_type",
+                    "expires_at"
+                ]
+            },
+            "query": [
+                "action_name",
+                "filter"
+            ]
+        }
+    },
+    "/exclusions/entities/cert-based-exclusions/v1": {
+        "delete": {
+            "query": [
+                "ids",
+                "comment"
+            ]
+        },
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "exclusions": [
+                    "applied_globally",
+                    "certificate",
+                    "children_cids",
+                    "comment",
+                    "description",
+                    "host_groups",
+                    "id",
+                    "name",
+                    "status"
+                ]
+            }
+        },
+        "post": {
+            "body": {
+                "exclusions": [
+                    "applied_globally",
+                    "certificate",
+                    "children_cids",
+                    "comment",
+                    "description",
+                    "host_groups",
+                    "name",
+                    "status"
+                ]
+            }
+        }
+    },
+    "/exclusions/entities/certificates/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/exclusions/queries/cert-based-exclusions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/alerts/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/allowlist/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/blocklist/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/detects/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/devicecount-collections/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/escalations/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/incidents/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falcon-complete-dashboards/queries/remediations/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/falconx/entities/artifacts/v1": {
+        "get": {
+            "query": [
+                "id",
+                "name",
+                "Accept-Encoding"
+            ]
+        }
+    },
+    "/falconx/entities/report-summaries/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/falconx/entities/reports/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/falconx/entities/submissions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/falconx/queries/reports/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/falconx/queries/submissions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/fdr/combined/schema-members/v1": {
+        "get": {}
+    },
+    "/fdr/entities/schema-events/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fdr/entities/schema-fields/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fdr/queries/schema-events/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "offset",
+                "filter",
+                "sort"
+            ]
+        }
+    },
+    "/fdr/queries/schema-fields/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "offset",
+                "filter",
+                "sort"
+            ]
+        }
+    },
+    "/fem/entities/external-assets/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "assets": [
+                    "cid",
+                    "criticality",
+                    "criticality_description",
+                    "id",
+                    "triage"
+                ]
+            }
+        }
+    },
+    "/fem/queries/external-assets/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/filevantage/entities/actions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "change_ids",
+                    "comment",
+                    "operation"
+                ]
+            }
+        }
+    },
+    "/filevantage/entities/change-content/v1": {
+        "get": {
+            "query": [
+                "id",
+                "Accept-Encoding"
+            ]
+        }
+    },
+    "/filevantage/entities/changes/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/filevantage/entities/policies-host-groups/v1": {
+        "patch": {
+            "query": [
+                "policy_id",
+                "action",
+                "ids"
+            ]
+        }
+    },
+    "/filevantage/entities/policies-precedence/v1": {
+        "patch": {
+            "query": [
+                "ids",
+                "type"
+            ]
+        }
+    },
+    "/filevantage/entities/policies-rule-groups/v1": {
+        "patch": {
+            "query": [
+                "policy_id",
+                "action",
+                "ids"
+            ]
+        }
+    },
+    "/filevantage/entities/policies/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "description",
+                    "name",
+                    "platform"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "description",
+                    "enabled",
+                    "id",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/filevantage/entities/policy-scheduled-exclusions/v1": {
+        "get": {
+            "query": [
+                "policy_id",
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "description",
+                    "name",
+                    "policy_id",
+                    "processes",
+                    "schedule_end",
+                    "schedule_start",
+                    "timezone",
+                    "users"
+                ],
+                "repeated": [
+                    "all_day",
+                    "end_time",
+                    "frequency",
+                    "monthly_days",
+                    "occurrence",
+                    "start_time",
+                    "weekly_days"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "policy_id",
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "description",
+                    "id",
+                    "name",
+                    "policy_id",
+                    "processes",
+                    "schedule_end",
+                    "schedule_start",
+                    "timezone",
+                    "users"
+                ],
+                "repeated": [
+                    "all_day",
+                    "end_time",
+                    "frequency",
+                    "monthly_days",
+                    "occurrence",
+                    "start_time",
+                    "weekly_days"
+                ]
+            }
+        }
+    },
+    "/filevantage/entities/rule-groups-rule-precedence/v1": {
+        "patch": {
+            "query": [
+                "rule_group_id",
+                "ids"
+            ]
+        }
+    },
+    "/filevantage/entities/rule-groups-rules/v1": {
+        "get": {
+            "query": [
+                "rule_group_id",
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "content_files",
+                    "content_registry_values",
+                    "created_timestamp",
+                    "depth",
+                    "description",
+                    "enable_content_capture",
+                    "enable_hash_capture",
+                    "exclude",
+                    "exclude_processes",
+                    "exclude_users",
+                    "id",
+                    "include",
+                    "include_processes",
+                    "include_users",
+                    "modified_timestamp",
+                    "path",
+                    "precedence",
+                    "rule_group_id",
+                    "severity",
+                    "type",
+                    "watch_attributes_directory_changes",
+                    "watch_attributes_file_changes",
+                    "watch_create_directory_changes",
+                    "watch_create_file_changes",
+                    "watch_create_key_changes",
+                    "watch_delete_directory_changes",
+                    "watch_delete_file_changes",
+                    "watch_delete_key_changes",
+                    "watch_delete_value_changes",
+                    "watch_permissions_directory_changes",
+                    "watch_permissions_file_changes",
+                    "watch_permissions_key_changes",
+                    "watch_rename_directory_changes",
+                    "watch_rename_file_changes",
+                    "watch_rename_key_changes",
+                    "watch_set_value_changes",
+                    "watch_write_file_changes"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "rule_group_id",
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "content_files",
+                    "content_registry_values",
+                    "created_timestamp",
+                    "depth",
+                    "description",
+                    "enable_content_capture",
+                    "enable_hash_capture",
+                    "exclude",
+                    "exclude_processes",
+                    "exclude_users",
+                    "id",
+                    "include",
+                    "include_processes",
+                    "include_users",
+                    "modified_timestamp",
+                    "path",
+                    "precedence",
+                    "rule_group_id",
+                    "severity",
+                    "type",
+                    "watch_attributes_directory_changes",
+                    "watch_attributes_file_changes",
+                    "watch_create_directory_changes",
+                    "watch_create_file_changes",
+                    "watch_create_key_changes",
+                    "watch_delete_directory_changes",
+                    "watch_delete_file_changes",
+                    "watch_delete_key_changes",
+                    "watch_delete_value_changes",
+                    "watch_permissions_directory_changes",
+                    "watch_permissions_file_changes",
+                    "watch_permissions_key_changes",
+                    "watch_rename_directory_changes",
+                    "watch_rename_file_changes",
+                    "watch_rename_key_changes",
+                    "watch_set_value_changes",
+                    "watch_write_file_changes"
+                ]
+            }
+        }
+    },
+    "/filevantage/entities/rule-groups/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "description",
+                    "name",
+                    "type"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "description",
+                    "id",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/filevantage/entities/workflow/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/filevantage/queries/actions/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/filevantage/queries/changes/v3": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/filevantage/queries/policies/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "type"
+            ]
+        }
+    },
+    "/filevantage/queries/policy-scheduled-exclusions/v1": {
+        "get": {
+            "query": [
+                "policy_id"
+            ]
+        }
+    },
+    "/filevantage/queries/rule-groups/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "type"
+            ]
+        }
+    },
+    "/fwmgr/entities/events/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/firewall-fields/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/network-locations-details/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/network-locations-metadata/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "cid",
+                    "dns_resolution_targets_polling_interval",
+                    "https_reachable_hosts_polling_interval",
+                    "icmp_request_targets_polling_interval",
+                    "location_precedence"
+                ]
+            },
+            "query": [
+                "comment"
+            ]
+        }
+    },
+    "/fwmgr/entities/network-locations-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "cid",
+                    "location_precedence"
+                ]
+            },
+            "query": [
+                "comment"
+            ]
+        }
+    },
+    "/fwmgr/entities/network-locations/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/platforms/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/policies/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/policies/v2": {
+        "put": {
+            "body": {
+                "root": [
+                    "default_inbound",
+                    "default_outbound",
+                    "enforce",
+                    "is_default_policy",
+                    "local_logging",
+                    "platform_id",
+                    "policy_id",
+                    "rule_group_ids",
+                    "test_mode",
+                    "tracking"
+                ]
+            }
+        }
+    },
+    "/fwmgr/entities/rule-groups/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "description",
+                    "enabled",
+                    "name",
+                    "platform"
+                ],
+                "rules": [
+                    "action",
+                    "address_family",
+                    "description",
+                    "direction",
+                    "enabled",
+                    "fields",
+                    "fqdn",
+                    "fqdn_enabled",
+                    "icmp",
+                    "local_address",
+                    "local_port",
+                    "log",
+                    "monitor",
+                    "name",
+                    "protocol",
+                    "remote_address",
+                    "remote_port",
+                    "temp_id"
+                ]
+            },
+            "query": [
+                "clone_id",
+                "library",
+                "comment"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "comment"
+            ]
+        },
+        "patch": {
+            "body": {
+                "diff_operations": [
+                    "from",
+                    "op",
+                    "path",
+                    "value"
+                ],
+                "root": [
+                    "diff_type",
+                    "id",
+                    "rule_ids",
+                    "rule_versions",
+                    "tracking"
+                ]
+            },
+            "query": [
+                "comment"
+            ]
+        }
+    },
+    "/fwmgr/entities/rule-groups/validation/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "description",
+                    "enabled",
+                    "name",
+                    "platform"
+                ],
+                "rules": [
+                    "action",
+                    "address_family",
+                    "description",
+                    "direction",
+                    "enabled",
+                    "fields",
+                    "fqdn",
+                    "fqdn_enabled",
+                    "icmp",
+                    "local_address",
+                    "local_port",
+                    "log",
+                    "monitor",
+                    "name",
+                    "protocol",
+                    "remote_address",
+                    "remote_port",
+                    "temp_id"
+                ]
+            },
+            "query": [
+                "clone_id",
+                "library",
+                "comment"
+            ]
+        },
+        "patch": {
+            "body": {
+                "diff_operations": [
+                    "from",
+                    "op",
+                    "path",
+                    "value"
+                ],
+                "root": [
+                    "diff_type",
+                    "id",
+                    "rule_ids",
+                    "rule_versions",
+                    "tracking"
+                ]
+            },
+            "query": [
+                "comment"
+            ]
+        }
+    },
+    "/fwmgr/entities/rules/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/fwmgr/entities/rules/validate-filepath/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "filepath_pattern",
+                    "filepath_test_string"
+                ]
+            }
+        }
+    },
+    "/fwmgr/queries/events/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "after",
+                "limit"
+            ]
+        }
+    },
+    "/fwmgr/queries/firewall-fields/v1": {
+        "get": {
+            "query": [
+                "platform_id",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/fwmgr/queries/network-locations/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "after",
+                "limit"
+            ]
+        }
+    },
+    "/fwmgr/queries/platforms/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/fwmgr/queries/rule-groups/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "after",
+                "limit"
+            ]
+        }
+    },
+    "/host-migration/entities/migration-destinations/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "device_ids",
+                    "filter"
+                ]
+            }
+        }
+    },
+    "/host-migration/entities/host-migrations/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/host-migration/entities/migrations/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "device_ids",
+                    "filter",
+                    "name",
+                    "target_cid"
+                ]
+            }
+        }
+    },
+    "/host-migration/queries/host-migrations/v1": {
+        "get": {
+            "query": [
+                "id",
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/host-migration/queries/migrations/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/identity-protection/entities/devices/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/identity-protection/entities/policy-rules/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/identity-protection/queries/devices/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/identity-protection/queries/policy-rules/v1": {
+        "get": {
+            "query": [
+                "enabled",
+                "simulation_mode",
+                "name"
+            ]
+        }
+    },
+    "/image-assessment/combined/vulnerability-lookups/v1": {
+        "post": {
+            "body": {
+                "applicationPackages": [
+                    "libraries",
+                    "type"
+                ],
+                "root": [
+                    "osversion"
+                ],
+                "packages": [
+                    "LayerHash",
+                    "LayerIndex",
+                    "MajorVersion",
+                    "PackageHash",
+                    "PackageProvider",
+                    "PackageSource",
+                    "Product",
+                    "SoftwareArchitecture",
+                    "Status",
+                    "Vendor"
+                ]
+            }
+        }
+    },
+    "/incidents/combined/crowdscores/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/incidents/entities/behaviors/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/incidents/entities/incident-actions/v1": {
+        "post": {
+            "body": {
+                "action_parameters": [
+                    "name",
+                    "value"
+                ],
+                "root": [
+                    "ids"
+                ]
+            },
+            "query": [
+                "update_detects",
+                "overwrite_detects"
+            ]
+        }
+    },
+    "/incidents/entities/incidents/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/incidents/queries/behaviors/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/incidents/queries/incidents/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/indicators/aggregates/devices-count/v1": {
+        "get": {
+            "query": [
+                "type",
+                "value"
+            ]
+        }
+    },
+    "/indicators/queries/devices/v1": {
+        "get": {
+            "query": [
+                "type",
+                "value",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/indicators/queries/processes/v1": {
+        "get": {
+            "query": [
+                "type",
+                "value",
+                "device_id",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/installation-tokens/entities/audit-events/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/installation-tokens/entities/customer-settings/v1": {
+        "patch": {
+            "body": {
+                "root": [
+                    "max_active_tokens",
+                    "tokens_required"
+                ]
+            }
+        }
+    },
+    "/installation-tokens/entities/tokens/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "expires_timestamp",
+                    "label",
+                    "type"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "expires_timestamp",
+                    "label",
+                    "revoked"
+                ]
+            },
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/installation-tokens/queries/audit-events/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/installation-tokens/queries/tokens/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/intel/combined/actors/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q",
+                "fields"
+            ]
+        }
+    },
+    "/intel/combined/indicators/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q",
+                "include_deleted",
+                "include_relations"
+            ]
+        }
+    },
+    "/intel/combined/reports/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q",
+                "fields"
+            ]
+        }
+    },
+    "/intel/entities/actors/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "fields"
+            ]
+        }
+    },
+    "/intel/entities/indicators/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/intel/entities/malware/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/intel/entities/mitre-reports/v1": {
+        "get": {
+            "query": [
+                "actor_id",
+                "format"
+            ]
+        }
+    },
+    "/intel/entities/mitre/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/intel/entities/report-files/v1": {
+        "get": {
+            "query": [
+                "id",
+                "ids"
+            ]
+        }
+    },
+    "/intel/entities/reports/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "fields"
+            ]
+        }
+    },
+    "/intel/entities/rules-files/v1": {
+        "get": {
+            "query": [
+                "Accept",
+                "id",
+                "format"
+            ]
+        }
+    },
+    "/intel/entities/rules-latest-files/v1": {
+        "get": {
+            "query": [
+                "Accept",
+                "If-None-Match",
+                "If-Modified-Since",
+                "type",
+                "format"
+            ]
+        }
+    },
+    "/intel/entities/rules/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/intel/entities/vulnerabilities/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/intel/queries/actors/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/intel/queries/indicators/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q",
+                "include_deleted",
+                "include_relations"
+            ]
+        }
+    },
+    "/intel/queries/malware/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/intel/queries/mitre-malware/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/intel/queries/mitre/v1": {
+        "get": {
+            "query": [
+                "id",
+                "ids"
+            ]
+        }
+    },
+    "/intel/queries/reports/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/intel/queries/rules/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "name",
+                "type",
+                "description",
+                "tags",
+                "min_created_date",
+                "max_created_date",
+                "q"
+            ]
+        }
+    },
+    "/intel/queries/vulnerabilities/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/ioarules/entities/pattern-severities/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ioarules/entities/platforms/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ioarules/entities/rule-groups/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "comment",
+                    "description",
+                    "name",
+                    "platform"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "comment",
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "comment",
+                    "description",
+                    "enabled",
+                    "id",
+                    "name",
+                    "rulegroup_version"
+                ]
+            }
+        }
+    },
+    "/ioarules/entities/rule-types/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ioarules/entities/rules/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/ioarules/entities/rules/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "comment",
+                    "description",
+                    "disposition_id",
+                    "name",
+                    "pattern_severity",
+                    "rulegroup_id",
+                    "ruletype_id"
+                ],
+                "field_values": [
+                    "final_value",
+                    "label",
+                    "name",
+                    "type",
+                    "value",
+                    "values"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "rule_group_id",
+                "comment",
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "comment",
+                    "rulegroup_id",
+                    "rulegroup_version"
+                ],
+                "rule_updates": [
+                    "description",
+                    "disposition_id",
+                    "enabled",
+                    "field_values",
+                    "instance_id",
+                    "name",
+                    "pattern_severity",
+                    "rulegroup_version"
+                ]
+            }
+        }
+    },
+    "/ioarules/entities/rules/v2": {
+        "patch": {
+            "body": {
+                "root": [
+                    "comment",
+                    "rulegroup_id",
+                    "rulegroup_version"
+                ],
+                "rule_updates": [
+                    "description",
+                    "disposition_id",
+                    "enabled",
+                    "field_values",
+                    "instance_id",
+                    "name",
+                    "pattern_severity",
+                    "rulegroup_version"
+                ]
+            }
+        }
+    },
+    "/ioarules/queries/pattern-severities/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/ioarules/queries/platforms/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/ioarules/queries/rule-groups-full/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/ioarules/queries/rule-groups/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/ioarules/queries/rule-types/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/ioarules/queries/rules/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/iocs/aggregates/indicators/device-count/v1": {
+        "get": {
+            "query": [
+                "type",
+                "value"
+            ]
+        }
+    },
+    "/iocs/combined/indicator/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort",
+                "after",
+                "from_parent"
+            ]
+        }
+    },
+    "/iocs/entities/actions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/iocs/entities/indicators/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "comment"
+                ],
+                "indicators": [
+                    "action",
+                    "applied_globally",
+                    "description",
+                    "expiration",
+                    "host_groups",
+                    "metadata",
+                    "mobile_action",
+                    "platforms",
+                    "severity",
+                    "source",
+                    "tags",
+                    "type",
+                    "value"
+                ]
+            },
+            "query": [
+                "retrodetects",
+                "ignore_warnings"
+            ]
+        },
+        "patch": {
+            "body": {
+                "bulk_update": [
+                    "action",
+                    "applied_globally",
+                    "description",
+                    "expiration",
+                    "filter",
+                    "from_parent",
+                    "host_groups",
+                    "metadata",
+                    "mobile_action",
+                    "platforms",
+                    "severity",
+                    "source",
+                    "tags"
+                ],
+                "root": [
+                    "comment"
+                ],
+                "indicators": [
+                    "action",
+                    "applied_globally",
+                    "description",
+                    "expiration",
+                    "host_groups",
+                    "id",
+                    "metadata",
+                    "mobile_action",
+                    "platforms",
+                    "severity",
+                    "source",
+                    "tags"
+                ]
+            },
+            "query": [
+                "retrodetects",
+                "ignore_warnings"
+            ]
+        }
+    },
+    "/iocs/queries/actions/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/iocs/queries/indicators/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort",
+                "after",
+                "from_parent"
+            ]
+        }
+    },
+    "/iocs/queries/ioc-types/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/iocs/queries/platforms/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/iocs/queries/severities/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/accounts/aws/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "is_horizon_acct",
+                "status",
+                "limit",
+                "offset"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "account_id",
+                    "region"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "query": [
+                "ids",
+                "region"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/accounts/azure/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "subscription_id",
+                "status",
+                "is_horizon_acct",
+                "limit",
+                "offset"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "subscription_id",
+                    "tenant_id"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/cloud_cluster/v1": {
+        "get": {
+            "query": [
+                "locations",
+                "ids",
+                "cluster_service",
+                "cluster_status",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/cloud-locations/v1": {
+        "get": {
+            "query": [
+                "clouds"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/config/azure/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/gen/scripts/v1": {
+        "get": {}
+    },
+    "/kubernetes-protection/entities/integration/agent/v1": {
+        "get": {
+            "query": [
+                "cluster_name",
+                "is_self_managed_cluster"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/kubernetes/clusters/v1": {
+        "get": {
+            "query": [
+                "cluster_names",
+                "status",
+                "account_ids",
+                "locations",
+                "cluster_service",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/scan/trigger/v1": {
+        "post": {
+            "query": [
+                "scan_type"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/service-principal/azure/v1": {
+        "patch": {
+            "query": [
+                "id",
+                "client_id"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/tenants/azure/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "status",
+                "limit",
+                "offset"
+            ]
+        }
+    },
+    "/kubernetes-protection/entities/user-script/azure/v1": {
+        "get": {
+            "query": [
+                "id",
+                "subscription_id"
+            ]
+        }
+    },
+    "/loggingapi/combined/repos/v1": {
+        "get": {
+            "query": [
+                "check_test_data"
+            ]
+        }
+    },
+    "/loggingapi/entities/saved-searches/execute/v1": {
+        "get": {
+            "query": [
+                "job_id",
+                "app_id",
+                "infer_json_types",
+                "job_status_only",
+                "limit",
+                "match_response_schema",
+                "metadata",
+                "offset"
+            ]
+        }
+    },
+    "/loggingapi/entities/views/v1": {
+        "get": {
+            "query": [
+                "check_test_data"
+            ]
+        }
+    },
+    "/malquery/aggregates/quotas/v1": {
+        "get": {}
+    },
+    "/malquery/entities/download-files/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/malquery/entities/metadata/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/malquery/entities/requests/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/malquery/entities/samples-multidownload/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "samples"
+                ]
+            }
+        }
+    },
+    "/message-center/entities/case-activities/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/message-center/entities/case-activity/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "body",
+                    "case_id",
+                    "type",
+                    "user_uuid"
+                ]
+            }
+        }
+    },
+    "/message-center/entities/case-attachment/v1": {
+        "get": {
+            "query": [
+                "id"
+            ]
+        },
+        "post": {
+            "formdata": [
+                "case_id",
+                "user_uuid",
+                "file"
+            ]
+        }
+    },
+    "/message-center/entities/cases/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/message-center/queries/case-activities/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset",
+                "case_id"
+            ]
+        }
+    },
+    "/message-center/queries/cases/v1": {
+        "get": {
+            "query": [
+                "limit",
+                "sort",
+                "filter",
+                "offset"
+            ]
+        }
+    },
+    "/mssp/entities/children/GET/v2": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/cid-group-members/v1": {
+        "post": {
+            "body": {
+                "resources": [
+                    "cid_group_id",
+                    "cids"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/cid-group-members/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "delete": {
+            "body": {
+                "resources": [
+                    "cid_group_id",
+                    "cids"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/cid-groups/v1": {
+        "post": {
+            "body": {
+                "resources": [
+                    "cid",
+                    "cid_group_id",
+                    "description",
+                    "is_default",
+                    "name"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "cid_group_ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "cid",
+                    "cid_group_id",
+                    "description",
+                    "is_default",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/cid-groups/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/mssp/entities/mssp-roles/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "cid_group_id",
+                    "id",
+                    "role_ids",
+                    "user_group_id"
+                ]
+            }
+        },
+        "delete": {
+            "body": {
+                "resources": [
+                    "cid_group_id",
+                    "id",
+                    "role_ids",
+                    "user_group_id"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/user-group-members/v1": {
+        "post": {
+            "body": {
+                "resources": [
+                    "user_group_id",
+                    "user_uuids"
+                ]
+            }
+        },
+        "delete": {
+            "body": {
+                "resources": [
+                    "user_group_id",
+                    "user_uuids"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/user-group-members/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/mssp/entities/user-groups/v1": {
+        "post": {
+            "body": {
+                "resources": [
+                    "cid",
+                    "description",
+                    "name",
+                    "user_group_id"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "user_group_ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "cid",
+                    "description",
+                    "name",
+                    "user_group_id"
+                ]
+            }
+        }
+    },
+    "/mssp/entities/user-groups/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/mssp/queries/children/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/mssp/queries/cid-group-members/v1": {
+        "get": {
+            "query": [
+                "cid",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/mssp/queries/cid-groups/v1": {
+        "get": {
+            "query": [
+                "name",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/mssp/queries/mssp-roles/v1": {
+        "get": {
+            "query": [
+                "user_group_id",
+                "cid_group_id",
+                "role_id",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/mssp/queries/user-group-members/v1": {
+        "get": {
+            "query": [
+                "user_uuid",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/mssp/queries/user-groups/v1": {
+        "get": {
+            "query": [
+                "name",
+                "sort",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/ods/entities/malicious-files/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ods/entities/scan-control-actions/cancel/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/ods/entities/scan-hosts/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ods/entities/scans/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "cloud_ml_level_detection",
+                    "cloud_ml_level_prevention",
+                    "cpu_priority",
+                    "description",
+                    "endpoint_notification",
+                    "file_paths",
+                    "host_groups",
+                    "hosts",
+                    "initiated_from",
+                    "max_duration",
+                    "pause_duration",
+                    "quarantine",
+                    "scan_exclusions",
+                    "scan_inclusions",
+                    "sensor_ml_level_detection",
+                    "sensor_ml_level_prevention"
+                ]
+            }
+        }
+    },
+    "/ods/entities/scans/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ods/entities/scheduled-scans/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/ods/queries/malicious-files/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/ods/queries/scan-hosts/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/ods/queries/scans/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/ods/queries/scheduled-scans/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/overwatch-dashboards/aggregates/detections-global-counts/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/overwatch-dashboards/aggregates/incidents-global-counts/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/overwatch-dashboards/aggregates/ow-events-global-counts/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/plugins/combined/configs/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/content-update/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/content-update-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/device-control-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/device-control/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/firewall-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/firewall/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/prevention-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/prevention/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/response-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/response/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/reveal-uninstall-token/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "audit_message",
+                    "device_id"
+                ]
+            }
+        }
+    },
+    "/policy/combined/sensor-update-builds/v1": {
+        "get": {
+            "query": [
+                "platform",
+                "stage"
+            ]
+        }
+    },
+    "/policy/combined/sensor-update-kernels/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/policy/combined/sensor-update-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/combined/sensor-update/v2": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/entities/content-update/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "description",
+                    "id",
+                    "name",
+                    "settings"
+                ]
+            }
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "description",
+                    "name",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "/policy/entities/content-update-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/policy/entities/default-device-control/v1": {
+        "get": {},
+        "patch": {
+            "body": {
+                "custom_notifications": [
+                    "blocked_notification",
+                    "restricted_notification"
+                ]
+            }
+        }
+    },
+    "/policy/entities/device-control-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids",
+                    "platform_name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/device-control/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "clone_id",
+                    "description",
+                    "name",
+                    "platform_name",
+                    "settings"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "description",
+                    "id",
+                    "name",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "/policy/entities/firewall-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids",
+                    "platform_name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/firewall/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "clone_id",
+                    "description",
+                    "name",
+                    "platform_name"
+                ]
+            },
+            "query": [
+                "clone_id"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "description",
+                    "id",
+                    "name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/ioa-exclusions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "cl_regex",
+                    "comment",
+                    "description",
+                    "detection_json",
+                    "groups",
+                    "ifn_regex",
+                    "name",
+                    "pattern_id",
+                    "pattern_name"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "comment"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "cl_regex",
+                    "comment",
+                    "description",
+                    "detection_json",
+                    "groups",
+                    "id",
+                    "ifn_regex",
+                    "name",
+                    "pattern_id",
+                    "pattern_name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/ml-exclusions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "comment",
+                    "excluded_from",
+                    "groups",
+                    "value"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "comment"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "comment",
+                    "groups",
+                    "id",
+                    "is_descendant_process",
+                    "value"
+                ]
+            }
+        }
+    },
+    "/policy/entities/prevention-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids",
+                    "platform_name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/prevention/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "clone_id",
+                    "description",
+                    "name",
+                    "platform_name",
+                    "settings"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "description",
+                    "id",
+                    "name",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "/policy/entities/response-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids",
+                    "platform_name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/response/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "clone_id",
+                    "description",
+                    "name",
+                    "platform_name",
+                    "settings"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "description",
+                    "id",
+                    "name",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "/policy/entities/sensor-update-precedence/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids",
+                    "platform_name"
+                ]
+            }
+        }
+    },
+    "/policy/entities/sensor-update/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/policy/entities/sensor-update/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "description",
+                    "name",
+                    "platform_name",
+                    "settings"
+                ]
+            }
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "description",
+                    "id",
+                    "name",
+                    "settings"
+                ]
+            }
+        }
+    },
+    "/policy/entities/sv-exclusions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "comment",
+                    "groups",
+                    "is_descendant_process",
+                    "value"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "comment"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "comment",
+                    "groups",
+                    "id",
+                    "is_descendant_process",
+                    "value"
+                ]
+            }
+        }
+    },
+    "/policy/queries/content-update/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/content-update-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/device-control-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/device-control/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/firewall-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/firewall/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/ioa-exclusions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "ifn_regex",
+                "cl_regex",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/ml-exclusions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/prevention-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/prevention/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/response-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/response/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/sensor-update-kernels/{distinct-field}/v1": {
+        "get": {
+            "query": [
+                "distinct-field",
+                "filter",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/policy/queries/sensor-update-members/v1": {
+        "get": {
+            "query": [
+                "id",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/sensor-update/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/policy/queries/sv-exclusions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/processes/entities/processes/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/quarantine/aggregates/action-update-count/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/quarantine/entities/quarantined-files/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/quarantine/entities/quarantined-files/v1": {
+        "patch": {
+            "body": {
+                "root": [
+                    "action",
+                    "comment",
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/quarantine/queries/quarantined-files/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "action",
+                    "comment",
+                    "filter",
+                    "q"
+                ]
+            }
+        }
+    },
+    "/quickscanpro/entities/files/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "formdata": [
+                "file",
+                "scan"
+            ]
+        }
+    },
+    "/quickscanpro/entities/scans/v1": {
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "sha256"
+                ]
+            }
+        }
+    },
+    "/quickscanpro/queries/scans/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/real-time-response-audit/combined/sessions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "sort",
+                "limit",
+                "offset",
+                "with_command_info"
+            ]
+        }
+    },
+    "/real-time-response/combined/batch-active-responder-command/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "base_command",
+                    "batch_id",
+                    "command_string",
+                    "optional_hosts",
+                    "persist_all"
+                ]
+            },
+            "query": [
+                "timeout",
+                "timeout_duration",
+                "host_timeout_duration"
+            ]
+        }
+    },
+    "/real-time-response/combined/batch-command/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "base_command",
+                    "batch_id",
+                    "command_string",
+                    "optional_hosts",
+                    "persist_all"
+                ]
+            },
+            "query": [
+                "timeout",
+                "timeout_duration",
+                "host_timeout_duration"
+            ]
+        }
+    },
+    "/real-time-response/combined/batch-get-command/v1": {
+        "get": {
+            "query": [
+                "timeout",
+                "timeout_duration",
+                "batch_get_cmd_req_id"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "batch_id",
+                    "file_path",
+                    "optional_hosts"
+                ]
+            },
+            "query": [
+                "timeout",
+                "timeout_duration",
+                "host_timeout_duration"
+            ]
+        }
+    },
+    "/real-time-response/combined/batch-init-session/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "existing_batch_id",
+                    "host_ids",
+                    "queue_offline"
+                ]
+            },
+            "query": [
+                "timeout",
+                "timeout_duration",
+                "host_timeout_duration"
+            ]
+        }
+    },
+    "/real-time-response/combined/batch-refresh-session/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "batch_id",
+                    "hosts_to_remove"
+                ]
+            },
+            "query": [
+                "timeout",
+                "timeout_duration"
+            ]
+        }
+    },
+    "/real-time-response/entities/active-responder-command/v1": {
+        "get": {
+            "query": [
+                "cloud_request_id",
+                "sequence_id"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "base_command",
+                    "command_string",
+                    "device_id",
+                    "id",
+                    "persist",
+                    "session_id"
+                ]
+            }
+        }
+    },
+    "/real-time-response/entities/admin-command/v1": {
+        "get": {
+            "query": [
+                "cloud_request_id",
+                "sequence_id"
+            ]
+        }
+    },
+    "/real-time-response/entities/command/v1": {
+        "get": {
+            "query": [
+                "cloud_request_id",
+                "sequence_id"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "base_command",
+                    "command_string",
+                    "device_id",
+                    "id",
+                    "persist",
+                    "session_id"
+                ]
+            }
+        }
+    },
+    "/real-time-response/entities/extracted-file-contents/v1": {
+        "get": {
+            "query": [
+                "session_id",
+                "sha256",
+                "filename"
+            ]
+        }
+    },
+    "/real-time-response/entities/falcon-scripts/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/real-time-response/entities/file/v2": {
+        "get": {
+            "query": [
+                "session_id"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "session_id"
+            ]
+        }
+    },
+    "/real-time-response/entities/put-files/v1": {
+        "post": {
+            "formdata": [
+                "file",
+                "description",
+                "name",
+                "comments_for_audit_log"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/real-time-response/entities/put-files/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/real-time-response/entities/queued-sessions/command/v1": {
+        "delete": {
+            "query": [
+                "session_id",
+                "cloud_request_id"
+            ]
+        }
+    },
+    "/real-time-response/entities/queued-sessions/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/real-time-response/entities/refresh-session/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "device_id",
+                    "origin",
+                    "queue_offline"
+                ]
+            }
+        }
+    },
+    "/real-time-response/entities/scripts/v1": {
+        "post": {
+            "formdata": [
+                "file",
+                "description",
+                "name",
+                "comments_for_audit_log",
+                "permission_type",
+                "content",
+                "platform"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "formdata": [
+                "id",
+                "file",
+                "description",
+                "name",
+                "comments_for_audit_log",
+                "permission_type",
+                "content",
+                "platform"
+            ]
+        }
+    },
+    "/real-time-response/entities/scripts/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/real-time-response/entities/sessions/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/real-time-response/entities/sessions/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "device_id",
+                    "origin",
+                    "queue_offline"
+                ]
+            },
+            "query": [
+                "timeout",
+                "timeout_duration"
+            ]
+        },
+        "delete": {
+            "query": [
+                "session_id"
+            ]
+        }
+    },
+    "/real-time-response/queries/falcon-scripts/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/real-time-response/queries/put-files/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/real-time-response/queries/scripts/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/real-time-response/queries/sessions/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/recon/aggregates/rules-preview/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "filter",
+                    "topic"
+                ]
+            }
+        }
+    },
+    "/recon/entities/actions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "actions": [
+                    "content_format",
+                    "frequency",
+                    "recipients",
+                    "trigger_matchless",
+                    "type"
+                ],
+                "root": [
+                    "rule_id"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "id"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "content_format",
+                    "frequency",
+                    "id",
+                    "recipients",
+                    "status",
+                    "trigger_matchless"
+                ]
+            }
+        }
+    },
+    "/recon/entities/export-files/v1": {
+        "get": {
+            "query": [
+                "id"
+            ]
+        }
+    },
+    "/recon/entities/exports/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "entity",
+                    "export_type",
+                    "filter",
+                    "human_readable",
+                    "sort"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/recon/entities/notifications-detailed-translated/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/recon/entities/notifications-detailed/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/recon/entities/notifications-exposed-data-records/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/recon/entities/notifications-translated/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/recon/entities/notifications/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "assigned_to_uuid",
+                    "id",
+                    "idp_send_status",
+                    "message",
+                    "status"
+                ]
+            }
+        }
+    },
+    "/recon/entities/rules/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "root": [
+                    "breach_monitor_only",
+                    "breach_monitoring_enabled",
+                    "filter",
+                    "match_on_tsq_result_types",
+                    "name",
+                    "originating_template_id",
+                    "permissions",
+                    "priority",
+                    "substring_matching_enabled",
+                    "topic"
+                ]
+            }
+        },
+        "delete": {
+            "query": [
+                "ids",
+                "notificationsDeletionRequested"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "breach_monitor_only",
+                    "breach_monitoring_enabled",
+                    "filter",
+                    "id",
+                    "match_on_tsq_result_types",
+                    "name",
+                    "permissions",
+                    "priority",
+                    "substring_matching_enabled"
+                ]
+            }
+        }
+    },
+    "/recon/queries/actions/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/recon/queries/notifications-exposed-data-records/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/recon/queries/notifications/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/recon/queries/rules/v1": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q",
+                "secondarySort"
+            ]
+        }
+    },
+    "/reports/entities/report-executions-download/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/reports/entities/report-executions/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/reports/entities/scheduled-reports/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/reports/queries/report-executions/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/reports/queries/scheduled-reports/v1": {
+        "get": {
+            "query": [
+                "sort",
+                "filter",
+                "q",
+                "offset",
+                "limit"
+            ]
+        }
+    },
+    "/samples/entities/samples/v3": {
+        "get": {
+            "query": [
+                "ids",
+                "password_protected"
+            ]
+        },
+        "delete": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/samples/queries/samples/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "sha256s"
+                ]
+            }
+        }
+    },
+    "/sensors/combined/installers/v2": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/sensors/entities/datafeed-actions/v1/{partition}": {
+        "post": {
+            "query": [
+                "action_name",
+                "appId",
+                "partition"
+            ]
+        }
+    },
+    "/sensors/entities/datafeed/v2": {
+        "get": {
+            "query": [
+                "appId",
+                "format"
+            ]
+        }
+    },
+    "/sensors/entities/download-installer/v2": {
+        "get": {
+            "query": [
+                "id"
+            ]
+        }
+    },
+    "/sensors/entities/installers/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/sensors/queries/installers/v2": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/settings/entities/policy-details/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/settings/entities/policy/v1": {
+        "get": {
+            "query": [
+                "service",
+                "policy-id",
+                "cloud-platform"
+            ]
+        },
+        "patch": {
+            "body": {
+                "resources": [
+                    "account_id",
+                    "account_ids",
+                    "enabled",
+                    "policy_id",
+                    "regions",
+                    "severity",
+                    "tag_excluded"
+                ]
+            }
+        }
+    },
+    "/settings/scan-schedule/v1": {
+        "get": {
+            "query": [
+                "cloud-platform"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "cloud_platform",
+                    "next_scan_timestamp",
+                    "scan_interval",
+                    "scan_schedule"
+                ]
+            }
+        }
+    },
+    "/snapshots/combined/deployments/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "offset",
+                "sort"
+            ]
+        }
+    },
+    "/snapshots/entities/accounts/v1": {
+        "post": {
+            "body": {
+                "aws_accounts": [
+                    "account_number",
+                    "batch_regions",
+                    "iam_external_id",
+                    "iam_role_arn",
+                    "kms_alias",
+                    "processing_account"
+                ]
+            }
+        }
+    },
+    "/snapshots/entities/deployments/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        },
+        "post": {
+            "body": {
+                "resources": [
+                    "account_id",
+                    "asset_identifier",
+                    "cloud_provider",
+                    "region"
+                ]
+            }
+        }
+    },
+    "/snapshots/entities/scanreports/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/spotlight/combined/evaluation-logic/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "filter",
+                "sort"
+            ]
+        }
+    },
+    "/spotlight/combined/vulnerabilities/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter",
+                "facet"
+            ]
+        }
+    },
+    "/spotlight/entities/evaluation-logic/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/spotlight/entities/remediations/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/spotlight/entities/vulnerabilities/v2": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/spotlight/queries/evaluation-logic/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "filter",
+                "sort"
+            ]
+        }
+    },
+    "/spotlight/queries/vulnerabilities/v1": {
+        "get": {
+            "query": [
+                "after",
+                "limit",
+                "sort",
+                "filter"
+            ]
+        }
+    },
+    "/threatgraph/combined/{vertex-type}/summary/v1": {
+        "get": {
+            "query": [
+                "vertex-type",
+                "ids",
+                "scope",
+                "nano"
+            ]
+        }
+    },
+    "/threatgraph/combined/edges/v1": {
+        "get": {
+            "query": [
+                "ids",
+                "limit",
+                "offset",
+                "edge_type",
+                "direction",
+                "scope",
+                "nano"
+            ]
+        }
+    },
+    "/threatgraph/combined/ran-on/v1": {
+        "get": {
+            "query": [
+                "value",
+                "type",
+                "limit",
+                "offset",
+                "nano"
+            ]
+        }
+    },
+    "/threatgraph/entities/{vertex-type}/v2": {
+        "get": {
+            "query": [
+                "vertex-type",
+                "ids",
+                "scope",
+                "nano"
+            ]
+        }
+    },
+    "/threatgraph/queries/edge-types/v1": {
+        "get": {}
+    },
+    "/ti/events/entities/events/GET/v2": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/ti/events/queries/events/v2": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/ti/rules/entities/rules/GET/v2": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/ti/rules/queries/rules/v2": {
+        "get": {
+            "query": [
+                "offset",
+                "limit",
+                "sort",
+                "filter",
+                "q"
+            ]
+        }
+    },
+    "/user-management/combined/user-roles/v1": {
+        "get": {
+            "query": [
+                "user_uuid",
+                "cid",
+                "direct_only",
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/user-management/entities/roles/v1": {
+        "get": {
+            "query": [
+                "cid",
+                "ids"
+            ]
+        }
+    },
+    "/user-management/entities/user-role-actions/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "action",
+                    "cid",
+                    "role_ids",
+                    "uuid",
+                    "expires_at"
+                ]
+            }
+        }
+    },
+    "/user-management/entities/users/GET/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            }
+        }
+    },
+    "/user-management/entities/users/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "cid",
+                    "first_name",
+                    "last_name",
+                    "password",
+                    "uid"
+                ]
+            },
+            "query": [
+                "validate_only"
+            ]
+        },
+        "delete": {
+            "query": [
+                "user_uuid"
+            ]
+        },
+        "patch": {
+            "body": {
+                "root": [
+                    "first_name",
+                    "last_name"
+                ]
+            },
+            "query": [
+                "user_uuid"
+            ]
+        }
+    },
+    "/user-management/queries/roles/v1": {
+        "get": {
+            "query": [
+                "cid",
+                "user_uuid",
+                "action"
+            ]
+        }
+    },
+    "/user-management/queries/users/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/workflows/combined/activities/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/workflows/combined/definitions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/workflows/combined/executions/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "offset",
+                "limit",
+                "sort"
+            ]
+        }
+    },
+    "/workflows/combined/triggers/v1": {
+        "get": {
+            "query": [
+                "filter"
+            ]
+        }
+    },
+    "/workflows/entities/definitions/export/v1": {
+        "get": {
+            "query": [
+                "id",
+                "sanitize"
+            ]
+        }
+    },
+    "/workflows/entities/definitions/import/v1": {
+        "post": {
+            "formdata": [
+                "data_file",
+                "name",
+                "validate_only"
+            ]
+        }
+    },
+    "/workflows/entities/execute/v1": {
+        "post": {
+            "body": {
+                "root": []
+            },
+            "query": [
+                "execution_cid",
+                "definition_id",
+                "name",
+                "key",
+                "depth",
+                "source_event_url"
+            ]
+        }
+    },
+    "/workflows/entities/execution-actions/v1": {
+        "post": {
+            "body": {
+                "root": [
+                    "ids"
+                ]
+            },
+            "query": [
+                "action_name"
+            ]
+        }
+    },
+    "/workflows/entities/execution-results/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/workflows/entities/human-inputs/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/zero-trust-assessment/entities/assessments/v1": {
+        "get": {
+            "query": [
+                "ids"
+            ]
+        }
+    },
+    "/zero-trust-assessment/queries/assessments/v1": {
+        "get": {
+            "query": [
+                "filter",
+                "limit",
+                "after",
+                "sort"
+            ]
+        }
     }
-  },
-  "/alerts/entities/alerts/v3": {
-    "patch": {
-      "body": {
-        "action_parameters": [
-          "name",
-          "value"
-        ],
-        "root": [
-          "composite_ids"
-        ]
-      },
-      "query": [
-        "include_hidden"
-      ]
-    }
-  },
-  "/alerts/queries/alerts/v2": {
-    "get": {
-      "query": [
-        "include_hidden",
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/archives/entities/archive-files/v1": {
-    "get": {
-      "query": [
-        "id",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/archives/entities/archives/v1": {
-    "get": {
-      "query": [
-        "id",
-        "include_files"
-      ]
-    },
-    "delete": {
-      "query": [
-        "id"
-      ]
-    }
-  },
-  "/archives/entities/archives/v2": {
-    "post": {
-      "formdata": [
-        "file",
-        "password",
-        "name",
-        "is_confidential",
-        "comment"
-      ]
-    }
-  },
-  "/archives/entities/extraction-files/v1": {
-    "get": {
-      "query": [
-        "id",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/archives/entities/extractions/v1": {
-    "get": {
-      "query": [
-        "id",
-        "include_files"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "extract_all",
-          "sha256"
-        ],
-        "files": [
-          "comment",
-          "is_confidential",
-          "name"
-        ]
-      }
-    }
-  },
-  "/billing-dashboards-usage/aggregates/weekly-average/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-aws/entities/account/v1": {
-    "get": {
-      "query": [
-        "scan-type",
-        "ids",
-        "iam_role_arns",
-        "organization-ids",
-        "status",
-        "limit",
-        "cspm_lite",
-        "migrated",
-        "offset",
-        "group_by"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "account_id",
-          "account_type",
-          "behavior_assessment_enabled",
-          "cloudtrail_region",
-          "dspm_enabled",
-          "dspm_role",
-          "iam_role_arn",
-          "is_master",
-          "organization_id",
-          "sensor_management_enabled",
-          "target_ous",
-          "use_existing_cloudtrail"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "organization-ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "account_id",
-          "behavior_assessment_enabled",
-          "cloudtrail_region",
-          "dspm_enabled",
-          "dspm_role",
-          "environment",
-          "iam_role_arn",
-          "remediation_region",
-          "remediation_tou_accepted",
-          "sensor_management_enabled",
-          "target_ous"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-aws/entities/user-scripts-download/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "template",
-        "account_type",
-        "accounts",
-        "behavior_assessment_enabled",
-        "sensor_management_enabled",
-        "dspm_enabled",
-        "dspm_regions",
-        "dspm_role",
-        "use_existing_cloudtrail",
-        "organization_id",
-        "aws_profile",
-        "custom_role_name"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-azure/entities/account/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "tenant_ids",
-        "scan-type",
-        "status",
-        "cspm_lite",
-        "limit",
-        "offset"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "account_type",
-          "client_id",
-          "default_subscription",
-          "subscription_id",
-          "tenant_id",
-          "years_valid"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "tenant_ids",
-        "retain_tenant"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-azure/entities/client-id/v1": {
-    "patch": {
-      "query": [
-        "id",
-        "tenant-id"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-azure/entities/default-subscription-id/v1": {
-    "patch": {
-      "query": [
-        "tenant-id",
-        "subscription_id"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-azure/entities/download-certificate/v1": {
-    "get": {
-      "query": [
-        "tenant_id",
-        "refresh",
-        "years_valid"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-azure/entities/management-group/v1": {
-    "delete": {
-      "query": [
-        "tenant_ids"
-      ]
-    },
-    "get": {
-      "query": [
-        "tenant_ids",
-        "limit",
-        "offset"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "default_subscription_id",
-          "tenant_id"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-azure/entities/user-scripts-download/v1": {
-    "get": {
-      "query": [
-        "tenant-id",
-        "subscription_ids",
-        "account_type",
-        "template",
-        "azure_management_group"
-      ]
-    }
-  },
-  "/cloud-connect-cspm-gcp/entities/account/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "get": {
-      "query": [
-        "parent_type",
-        "ids",
-        "scan-type",
-        "status",
-        "limit",
-        "offset",
-        "sort"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "environment",
-          "parent_id",
-          "service_account"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-gcp/entities/account/v2": {
-    "post": {
-      "body": {
-        "resources": [
-          "client_email",
-          "client_id",
-          "parent_id",
-          "parent_type",
-          "private_key",
-          "private_key_id",
-          "project_id",
-          "service_account_conditions",
-          "service_account_id"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-gcp/entities/account/validate/v1": {
-    "post": {
-      "body": {
-        "resources": [
-          "parent_id"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-gcp/entities/service-accounts/v1": {
-    "get": {
-      "query": [
-        "id"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "client_email",
-          "client_id",
-          "private_key",
-          "private_key_id",
-          "project_id",
-          "service_account_conditions",
-          "service_account_id"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-gcp/entities/service-accounts/validate/v1": {
-    "post": {
-      "body": {
-        "resources": [
-          "client_email",
-          "client_id",
-          "private_key",
-          "private_key_id",
-          "project_id",
-          "service_account_conditions",
-          "service_account_id"
-        ]
-      }
-    }
-  },
-  "/cloud-connect-cspm-gcp/entities/user-scripts-download/v1": {
-    "get": {
-      "query": [
-        "parent_type",
-        "ids"
-      ]
-    }
-  },
-  "/configuration-assessment/combined/assessments/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter",
-        "facet"
-      ]
-    }
-  },
-  "/configuration-assessment/entities/evaluation-logic/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/configuration-assessment/entities/rule-details/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/compliance-by-clusters/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/compliance-by-rules/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-containers-by-rules/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-containers-count-by-severity/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-images-by-rules/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-images-count-by-severity/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-rules-by-clusters/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-rules-by-images/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/failed-rules-count-by-severity/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-compliance/aggregates/rules-by-status/v2": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/clusters/count-by-date/v1": {
-    "get": {}
-  },
-  "/container-security/aggregates/clusters/count-by-kubernetes-version/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/clusters/count-by-status/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/clusters/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/container-alerts/count-by-severity/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/container-alerts/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/count-by-date/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/count-by-registry/v1": {
-    "get": {
-      "query": [
-        "under_assessment",
-        "limit"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/count-by-zero-day/v1": {
-    "get": {}
-  },
-  "/container-security/aggregates/containers/count-vulnerable-images/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/find-by-runtimeversion/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "offset",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/group-by-managed/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/image-detections-count-by-date/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/images-by-state/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/sensor-coverage/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/containers/vulnerability-count-by-severity/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/deployments/count-by-date/v1": {
-    "get": {}
-  },
-  "/container-security/aggregates/deployments/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/detections/count-by-severity/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/detections/count-by-type/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/detections/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/drift-indicators/count-by-date/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit"
-      ]
-    }
-  },
-  "/container-security/aggregates/drift-indicators/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/images/assessment-history/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/images/count-by-distinct/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/images/count-by-os-distribution/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/images/count-by-state/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/images/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/images/most-used/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/kubernetes-ioms/count-by-date/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/kubernetes-ioms/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/namespaces/count-by-date/v1": {
-    "get": {}
-  },
-  "/container-security/aggregates/namespaces/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/nodes/count-by-cloud/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/nodes/count-by-container-engine-version/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/nodes/count-by-date/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/nodes/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/packages/count-by-zero-day/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/pods/count-by-date/v1": {
-    "get": {}
-  },
-  "/container-security/aggregates/pods/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/unidentified-containers/count-by-date/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/unidentified-containers/count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/container-security/aggregates/vulnerabilities/count-by-actively-exploited/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/aggregates/vulnerabilities/count-by-cps-rating/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/aggregates/vulnerabilities/count-by-cvss-score/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/aggregates/vulnerabilities/count-by-severity/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/aggregates/vulnerabilities/count/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/clusters/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/container-alerts/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset",
-        "sort"
-      ]
-    }
-  },
-  "/container-security/combined/container-images/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/containers/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/deployments/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/detections/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/drift-indicators/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/image-assessment/images/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/images/detail/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "with_config",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/kubernetes-ioms/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/nodes/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/packages/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "only_zero_day_affected",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/pods/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/combined/vulnerabilities/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset",
-        "sort"
-      ]
-    }
-  },
-  "/container-security/combined/vulnerabilities/info/v1": {
-    "get": {
-      "query": [
-        "cve_id",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/entities/base-images/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "base_images": [
-          "image_digest",
-          "image_id",
-          "registry",
-          "repository",
-          "tag"
-        ]
-      }
-    }
-  },
-  "/container-security/entities/drift-indicators/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/container-security/entities/image-assessment-policies/v1": {
-    "delete": {
-      "query": [
-        "id"
-      ]
-    },
-    "get": {},
-    "post": {
-      "body": {
-        "root": [
-          "description",
-          "name"
-        ]
-      }
-    }
-  },
-  "/container-security/entities/image-assessment-policy-exclusions/v1": {
-    "get": {}
-  },
-  "/container-security/entities/image-assessment-policy-groups/v1": {
-    "delete": {
-      "query": [
-        "id"
-      ]
-    },
-    "get": {}
-  },
-  "/container-security/entities/image-assessment-policy-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "precedence"
-        ]
-      }
-    }
-  },
-  "/container-security/entities/kubernetes-ioms/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/container-security/entities/registries/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/container-security/queries/detections/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/queries/drift-indicators/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/queries/kubernetes-ioms/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/container-security/queries/registries/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "offset",
-        "sort"
-      ]
-    }
-  },
-  "/correlation-rules/combined/rules/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "q",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/correlation-rules/entities/rules/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/correlation-rules/queries/rules/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "q",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/delivery-settings/entities/delivery-settings/v1": {
-    "get": {},
-    "post": {
-      "body": {
-        "delivery_settings": [
-          "delivery_cadence",
-          "delivery_type"
-        ]
-      }
-    }
-  },
-  "/detects/entities/detects/v2": {
-    "patch": {
-      "body": {
-        "root": [
-          "assigned_to_uuid",
-          "comment",
-          "ids",
-          "new_behaviors_processed",
-          "show_in_ui",
-          "status"
-        ]
-      }
-    }
-  },
-  "/detects/entities/ioa/v1": {
-    "get": {
-      "query": [
-        "cloud_provider",
-        "service",
-        "account_id",
-        "aws_account_id",
-        "azure_subscription_id",
-        "azure_tenant_id",
-        "state",
-        "date_time_since",
-        "since",
-        "severity",
-        "next_token",
-        "limit",
-        "resource_id",
-        "resource_uuid"
-      ]
-    }
-  },
-  "/detects/entities/iom/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/detects/entities/summaries/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/detects/queries/detects/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/detects/queries/iom/v2": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset",
-        "next_token"
-      ]
-    }
-  },
-  "/devices/combined/devices/login-history/v2": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/devices/combined/devices/network-address-history/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/devices/combined/host-group-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/devices/combined/host-groups/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/devices/entities/devices-actions/v2": {
-    "post": {
-      "body": {
-        "action_parameters": [
-          "name",
-          "value"
-        ],
-        "root": [
-          "ids"
-        ]
-      },
-      "query": [
-        "action_name"
-      ]
-    }
-  },
-  "/devices/entities/devices/tags/v1": {
-    "patch": {
-      "body": {
-        "root": [
-          "action",
-          "device_ids",
-          "tags"
-        ]
-      }
-    }
-  },
-  "/devices/entities/devices/v2": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/devices/entities/host-groups/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "assignment_rule",
-          "description",
-          "group_type",
-          "name"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "assignment_rule",
-          "description",
-          "id",
-          "name"
-        ]
-      }
-    }
-  },
-  "/devices/entities/online-state/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/devices/queries/devices-hidden/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/devices/queries/devices-scroll/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/devices/queries/host-group-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/devices/queries/host-groups/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/device-content/entities/states/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/device-content/queries/states/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "offset",
-        "filter"
-      ]
-    }
-  },
-  "/discover/combined/applications/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter",
-        "facet"
-      ]
-    }
-  },
-  "/discover/combined/hosts/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter",
-        "facet"
-      ]
-    }
-  },
-  "/discover/entities/accounts/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/discover/entities/applications/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/discover/entities/hosts/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/discover/entities/iot-hosts/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/discover/entities/logins/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/discover/queries/accounts/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/discover/queries/applications/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/discover/queries/hosts/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/discover/queries/iot-hosts/v2": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/discover/queries/logins/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/enrollments/entities/details/v4": {
-    "post": {
-      "body": {
-        "root": [
-          "email_addresses",
-          "enrollment_type",
-          "expires_at"
-        ]
-      },
-      "query": [
-        "action_name",
-        "filter"
-      ]
-    }
-  },
-  "/exclusions/entities/cert-based-exclusions/v1": {
-    "delete": {
-      "query": [
-        "ids",
-        "comment"
-      ]
-    },
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "exclusions": [
-          "applied_globally",
-          "certificate",
-          "children_cids",
-          "comment",
-          "description",
-          "host_groups",
-          "id",
-          "name",
-          "status"
-        ]
-      }
-    },
-    "post": {
-      "body": {
-        "exclusions": [
-          "applied_globally",
-          "certificate",
-          "children_cids",
-          "comment",
-          "description",
-          "host_groups",
-          "name",
-          "status"
-        ]
-      }
-    }
-  },
-  "/exclusions/entities/certificates/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/exclusions/queries/cert-based-exclusions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/alerts/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/allowlist/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/blocklist/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/detects/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/devicecount-collections/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/escalations/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/incidents/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falcon-complete-dashboards/queries/remediations/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/falconx/entities/artifacts/v1": {
-    "get": {
-      "query": [
-        "id",
-        "name",
-        "Accept-Encoding"
-      ]
-    }
-  },
-  "/falconx/entities/report-summaries/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/falconx/entities/reports/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/falconx/entities/submissions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/falconx/queries/reports/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/falconx/queries/submissions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/fdr/combined/schema-members/v1": {
-    "get": {}
-  },
-  "/fdr/entities/schema-events/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fdr/entities/schema-fields/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fdr/queries/schema-events/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "offset",
-        "filter",
-        "sort"
-      ]
-    }
-  },
-  "/fdr/queries/schema-fields/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "offset",
-        "filter",
-        "sort"
-      ]
-    }
-  },
-  "/fem/entities/external-assets/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "assets": [
-          "cid",
-          "criticality",
-          "criticality_description",
-          "id",
-          "triage"
-        ]
-      }
-    }
-  },
-  "/fem/queries/external-assets/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/filevantage/entities/actions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "change_ids",
-          "comment",
-          "operation"
-        ]
-      }
-    }
-  },
-  "/filevantage/entities/change-content/v1": {
-    "get": {
-      "query": [
-        "id",
-        "Accept-Encoding"
-      ]
-    }
-  },
-  "/filevantage/entities/changes/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/filevantage/entities/policies-host-groups/v1": {
-    "patch": {
-      "query": [
-        "policy_id",
-        "action",
-        "ids"
-      ]
-    }
-  },
-  "/filevantage/entities/policies-precedence/v1": {
-    "patch": {
-      "query": [
-        "ids",
-        "type"
-      ]
-    }
-  },
-  "/filevantage/entities/policies-rule-groups/v1": {
-    "patch": {
-      "query": [
-        "policy_id",
-        "action",
-        "ids"
-      ]
-    }
-  },
-  "/filevantage/entities/policies/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "description",
-          "name",
-          "platform"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "description",
-          "enabled",
-          "id",
-          "name"
-        ]
-      }
-    }
-  },
-  "/filevantage/entities/policy-scheduled-exclusions/v1": {
-    "get": {
-      "query": [
-        "policy_id",
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "description",
-          "name",
-          "policy_id",
-          "processes",
-          "schedule_end",
-          "schedule_start",
-          "timezone",
-          "users"
-        ],
-        "repeated": [
-          "all_day",
-          "end_time",
-          "frequency",
-          "monthly_days",
-          "occurrence",
-          "start_time",
-          "weekly_days"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "policy_id",
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "description",
-          "id",
-          "name",
-          "policy_id",
-          "processes",
-          "schedule_end",
-          "schedule_start",
-          "timezone",
-          "users"
-        ],
-        "repeated": [
-          "all_day",
-          "end_time",
-          "frequency",
-          "monthly_days",
-          "occurrence",
-          "start_time",
-          "weekly_days"
-        ]
-      }
-    }
-  },
-  "/filevantage/entities/rule-groups-rule-precedence/v1": {
-    "patch": {
-      "query": [
-        "rule_group_id",
-        "ids"
-      ]
-    }
-  },
-  "/filevantage/entities/rule-groups-rules/v1": {
-    "get": {
-      "query": [
-        "rule_group_id",
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "content_files",
-          "content_registry_values",
-          "created_timestamp",
-          "depth",
-          "description",
-          "enable_content_capture",
-          "enable_hash_capture",
-          "exclude",
-          "exclude_processes",
-          "exclude_users",
-          "id",
-          "include",
-          "include_processes",
-          "include_users",
-          "modified_timestamp",
-          "path",
-          "precedence",
-          "rule_group_id",
-          "severity",
-          "type",
-          "watch_attributes_directory_changes",
-          "watch_attributes_file_changes",
-          "watch_create_directory_changes",
-          "watch_create_file_changes",
-          "watch_create_key_changes",
-          "watch_delete_directory_changes",
-          "watch_delete_file_changes",
-          "watch_delete_key_changes",
-          "watch_delete_value_changes",
-          "watch_permissions_directory_changes",
-          "watch_permissions_file_changes",
-          "watch_permissions_key_changes",
-          "watch_rename_directory_changes",
-          "watch_rename_file_changes",
-          "watch_rename_key_changes",
-          "watch_set_value_changes",
-          "watch_write_file_changes"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "rule_group_id",
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "content_files",
-          "content_registry_values",
-          "created_timestamp",
-          "depth",
-          "description",
-          "enable_content_capture",
-          "enable_hash_capture",
-          "exclude",
-          "exclude_processes",
-          "exclude_users",
-          "id",
-          "include",
-          "include_processes",
-          "include_users",
-          "modified_timestamp",
-          "path",
-          "precedence",
-          "rule_group_id",
-          "severity",
-          "type",
-          "watch_attributes_directory_changes",
-          "watch_attributes_file_changes",
-          "watch_create_directory_changes",
-          "watch_create_file_changes",
-          "watch_create_key_changes",
-          "watch_delete_directory_changes",
-          "watch_delete_file_changes",
-          "watch_delete_key_changes",
-          "watch_delete_value_changes",
-          "watch_permissions_directory_changes",
-          "watch_permissions_file_changes",
-          "watch_permissions_key_changes",
-          "watch_rename_directory_changes",
-          "watch_rename_file_changes",
-          "watch_rename_key_changes",
-          "watch_set_value_changes",
-          "watch_write_file_changes"
-        ]
-      }
-    }
-  },
-  "/filevantage/entities/rule-groups/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "description",
-          "name",
-          "type"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "description",
-          "id",
-          "name"
-        ]
-      }
-    }
-  },
-  "/filevantage/entities/workflow/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/filevantage/queries/actions/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/filevantage/queries/changes/v3": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/filevantage/queries/policies/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "type"
-      ]
-    }
-  },
-  "/filevantage/queries/policy-scheduled-exclusions/v1": {
-    "get": {
-      "query": [
-        "policy_id"
-      ]
-    }
-  },
-  "/filevantage/queries/rule-groups/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "type"
-      ]
-    }
-  },
-  "/fwmgr/entities/events/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/firewall-fields/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/network-locations-details/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/network-locations-metadata/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "cid",
-          "dns_resolution_targets_polling_interval",
-          "https_reachable_hosts_polling_interval",
-          "icmp_request_targets_polling_interval",
-          "location_precedence"
-        ]
-      },
-      "query": [
-        "comment"
-      ]
-    }
-  },
-  "/fwmgr/entities/network-locations-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "cid",
-          "location_precedence"
-        ]
-      },
-      "query": [
-        "comment"
-      ]
-    }
-  },
-  "/fwmgr/entities/network-locations/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/platforms/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/policies/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/policies/v2": {
-    "put": {
-      "body": {
-        "root": [
-          "default_inbound",
-          "default_outbound",
-          "enforce",
-          "is_default_policy",
-          "local_logging",
-          "platform_id",
-          "policy_id",
-          "rule_group_ids",
-          "test_mode",
-          "tracking"
-        ]
-      }
-    }
-  },
-  "/fwmgr/entities/rule-groups/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "description",
-          "enabled",
-          "name",
-          "platform"
-        ],
-        "rules": [
-          "action",
-          "address_family",
-          "description",
-          "direction",
-          "enabled",
-          "fields",
-          "fqdn",
-          "fqdn_enabled",
-          "icmp",
-          "local_address",
-          "local_port",
-          "log",
-          "monitor",
-          "name",
-          "protocol",
-          "remote_address",
-          "remote_port",
-          "temp_id"
-        ]
-      },
-      "query": [
-        "clone_id",
-        "library",
-        "comment"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "comment"
-      ]
-    },
-    "patch": {
-      "body": {
-        "diff_operations": [
-          "from",
-          "op",
-          "path",
-          "value"
-        ],
-        "root": [
-          "diff_type",
-          "id",
-          "rule_ids",
-          "rule_versions",
-          "tracking"
-        ]
-      },
-      "query": [
-        "comment"
-      ]
-    }
-  },
-  "/fwmgr/entities/rule-groups/validation/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "description",
-          "enabled",
-          "name",
-          "platform"
-        ],
-        "rules": [
-          "action",
-          "address_family",
-          "description",
-          "direction",
-          "enabled",
-          "fields",
-          "fqdn",
-          "fqdn_enabled",
-          "icmp",
-          "local_address",
-          "local_port",
-          "log",
-          "monitor",
-          "name",
-          "protocol",
-          "remote_address",
-          "remote_port",
-          "temp_id"
-        ]
-      },
-      "query": [
-        "clone_id",
-        "library",
-        "comment"
-      ]
-    },
-    "patch": {
-      "body": {
-        "diff_operations": [
-          "from",
-          "op",
-          "path",
-          "value"
-        ],
-        "root": [
-          "diff_type",
-          "id",
-          "rule_ids",
-          "rule_versions",
-          "tracking"
-        ]
-      },
-      "query": [
-        "comment"
-      ]
-    }
-  },
-  "/fwmgr/entities/rules/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/fwmgr/entities/rules/validate-filepath/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "filepath_pattern",
-          "filepath_test_string"
-        ]
-      }
-    }
-  },
-  "/fwmgr/queries/events/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "after",
-        "limit"
-      ]
-    }
-  },
-  "/fwmgr/queries/firewall-fields/v1": {
-    "get": {
-      "query": [
-        "platform_id",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/fwmgr/queries/network-locations/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "after",
-        "limit"
-      ]
-    }
-  },
-  "/fwmgr/queries/platforms/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/fwmgr/queries/rule-groups/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "after",
-        "limit"
-      ]
-    }
-  },
-  "/host-migration/entities/migration-destinations/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "device_ids",
-          "filter"
-        ]
-      }
-    }
-  },
-  "/host-migration/entities/host-migrations/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/host-migration/entities/migrations/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "device_ids",
-          "filter",
-          "name",
-          "target_cid"
-        ]
-      }
-    }
-  },
-  "/host-migration/queries/host-migrations/v1": {
-    "get": {
-      "query": [
-        "id",
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/host-migration/queries/migrations/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/identity-protection/entities/devices/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/identity-protection/entities/policy-rules/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/identity-protection/queries/devices/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/identity-protection/queries/policy-rules/v1": {
-    "get": {
-      "query": [
-        "enabled",
-        "simulation_mode",
-        "name"
-      ]
-    }
-  },
-  "/image-assessment/combined/vulnerability-lookups/v1": {
-    "post": {
-      "body": {
-        "applicationPackages": [
-          "libraries",
-          "type"
-        ],
-        "root": [
-          "osversion"
-        ],
-        "packages": [
-          "LayerHash",
-          "LayerIndex",
-          "MajorVersion",
-          "PackageHash",
-          "PackageProvider",
-          "PackageSource",
-          "Product",
-          "SoftwareArchitecture",
-          "Status",
-          "Vendor"
-        ]
-      }
-    }
-  },
-  "/incidents/combined/crowdscores/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/incidents/entities/behaviors/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/incidents/entities/incident-actions/v1": {
-    "post": {
-      "body": {
-        "action_parameters": [
-          "name",
-          "value"
-        ],
-        "root": [
-          "ids"
-        ]
-      },
-      "query": [
-        "update_detects",
-        "overwrite_detects"
-      ]
-    }
-  },
-  "/incidents/entities/incidents/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/incidents/queries/behaviors/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/incidents/queries/incidents/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/indicators/aggregates/devices-count/v1": {
-    "get": {
-      "query": [
-        "type",
-        "value"
-      ]
-    }
-  },
-  "/indicators/queries/devices/v1": {
-    "get": {
-      "query": [
-        "type",
-        "value",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/indicators/queries/processes/v1": {
-    "get": {
-      "query": [
-        "type",
-        "value",
-        "device_id",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/installation-tokens/entities/audit-events/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/installation-tokens/entities/customer-settings/v1": {
-    "patch": {
-      "body": {
-        "root": [
-          "max_active_tokens",
-          "tokens_required"
-        ]
-      }
-    }
-  },
-  "/installation-tokens/entities/tokens/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "expires_timestamp",
-          "label",
-          "type"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "expires_timestamp",
-          "label",
-          "revoked"
-        ]
-      },
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/installation-tokens/queries/audit-events/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/installation-tokens/queries/tokens/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/intel/combined/actors/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q",
-        "fields"
-      ]
-    }
-  },
-  "/intel/combined/indicators/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q",
-        "include_deleted",
-        "include_relations"
-      ]
-    }
-  },
-  "/intel/combined/reports/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q",
-        "fields"
-      ]
-    }
-  },
-  "/intel/entities/actors/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "fields"
-      ]
-    }
-  },
-  "/intel/entities/indicators/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/intel/entities/malware/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/intel/entities/mitre-reports/v1": {
-    "get": {
-      "query": [
-        "actor_id",
-        "format"
-      ]
-    }
-  },
-  "/intel/entities/mitre/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/intel/entities/report-files/v1": {
-    "get": {
-      "query": [
-        "id",
-        "ids"
-      ]
-    }
-  },
-  "/intel/entities/reports/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "fields"
-      ]
-    }
-  },
-  "/intel/entities/rules-files/v1": {
-    "get": {
-      "query": [
-        "Accept",
-        "id",
-        "format"
-      ]
-    }
-  },
-  "/intel/entities/rules-latest-files/v1": {
-    "get": {
-      "query": [
-        "Accept",
-        "If-None-Match",
-        "If-Modified-Since",
-        "type",
-        "format"
-      ]
-    }
-  },
-  "/intel/entities/rules/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/intel/entities/vulnerabilities/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/intel/queries/actors/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/intel/queries/indicators/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q",
-        "include_deleted",
-        "include_relations"
-      ]
-    }
-  },
-  "/intel/queries/malware/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/intel/queries/mitre-malware/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/intel/queries/mitre/v1": {
-    "get": {
-      "query": [
-        "id",
-        "ids"
-      ]
-    }
-  },
-  "/intel/queries/reports/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/intel/queries/rules/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "name",
-        "type",
-        "description",
-        "tags",
-        "min_created_date",
-        "max_created_date",
-        "q"
-      ]
-    }
-  },
-  "/intel/queries/vulnerabilities/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/ioarules/entities/pattern-severities/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ioarules/entities/platforms/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ioarules/entities/rule-groups/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "comment",
-          "description",
-          "name",
-          "platform"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "comment",
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "comment",
-          "description",
-          "enabled",
-          "id",
-          "name",
-          "rulegroup_version"
-        ]
-      }
-    }
-  },
-  "/ioarules/entities/rule-types/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ioarules/entities/rules/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/ioarules/entities/rules/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "comment",
-          "description",
-          "disposition_id",
-          "name",
-          "pattern_severity",
-          "rulegroup_id",
-          "ruletype_id"
-        ],
-        "field_values": [
-          "final_value",
-          "label",
-          "name",
-          "type",
-          "value",
-          "values"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "rule_group_id",
-        "comment",
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "comment",
-          "rulegroup_id",
-          "rulegroup_version"
-        ],
-        "rule_updates": [
-          "description",
-          "disposition_id",
-          "enabled",
-          "field_values",
-          "instance_id",
-          "name",
-          "pattern_severity",
-          "rulegroup_version"
-        ]
-      }
-    }
-  },
-  "/ioarules/entities/rules/v2": {
-    "patch": {
-      "body": {
-        "root": [
-          "comment",
-          "rulegroup_id",
-          "rulegroup_version"
-        ],
-        "rule_updates": [
-          "description",
-          "disposition_id",
-          "enabled",
-          "field_values",
-          "instance_id",
-          "name",
-          "pattern_severity",
-          "rulegroup_version"
-        ]
-      }
-    }
-  },
-  "/ioarules/queries/pattern-severities/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/ioarules/queries/platforms/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/ioarules/queries/rule-groups-full/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/ioarules/queries/rule-groups/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/ioarules/queries/rule-types/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/ioarules/queries/rules/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/iocs/aggregates/indicators/device-count/v1": {
-    "get": {
-      "query": [
-        "type",
-        "value"
-      ]
-    }
-  },
-  "/iocs/combined/indicator/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort",
-        "after",
-        "from_parent"
-      ]
-    }
-  },
-  "/iocs/entities/actions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/iocs/entities/indicators/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "comment"
-        ],
-        "indicators": [
-          "action",
-          "applied_globally",
-          "description",
-          "expiration",
-          "host_groups",
-          "metadata",
-          "mobile_action",
-          "platforms",
-          "severity",
-          "source",
-          "tags",
-          "type",
-          "value"
-        ]
-      },
-      "query": [
-        "retrodetects",
-        "ignore_warnings"
-      ]
-    },
-    "patch": {
-      "body": {
-        "bulk_update": [
-          "action",
-          "applied_globally",
-          "description",
-          "expiration",
-          "filter",
-          "from_parent",
-          "host_groups",
-          "metadata",
-          "mobile_action",
-          "platforms",
-          "severity",
-          "source",
-          "tags"
-        ],
-        "root": [
-          "comment"
-        ],
-        "indicators": [
-          "action",
-          "applied_globally",
-          "description",
-          "expiration",
-          "host_groups",
-          "id",
-          "metadata",
-          "mobile_action",
-          "platforms",
-          "severity",
-          "source",
-          "tags"
-        ]
-      },
-      "query": [
-        "retrodetects",
-        "ignore_warnings"
-      ]
-    }
-  },
-  "/iocs/queries/actions/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/iocs/queries/indicators/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort",
-        "after",
-        "from_parent"
-      ]
-    }
-  },
-  "/iocs/queries/ioc-types/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/iocs/queries/platforms/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/iocs/queries/severities/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/accounts/aws/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "is_horizon_acct",
-        "status",
-        "limit",
-        "offset"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "account_id",
-          "region"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "query": [
-        "ids",
-        "region"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/accounts/azure/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "subscription_id",
-        "status",
-        "is_horizon_acct",
-        "limit",
-        "offset"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "subscription_id",
-          "tenant_id"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/cloud_cluster/v1": {
-    "get": {
-      "query": [
-        "locations",
-        "ids",
-        "cluster_service",
-        "cluster_status",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/cloud-locations/v1": {
-    "get": {
-      "query": [
-        "clouds"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/config/azure/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/gen/scripts/v1": {
-    "get": {}
-  },
-  "/kubernetes-protection/entities/integration/agent/v1": {
-    "get": {
-      "query": [
-        "cluster_name",
-        "is_self_managed_cluster"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/kubernetes/clusters/v1": {
-    "get": {
-      "query": [
-        "cluster_names",
-        "status",
-        "account_ids",
-        "locations",
-        "cluster_service",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/scan/trigger/v1": {
-    "post": {
-      "query": [
-        "scan_type"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/service-principal/azure/v1": {
-    "patch": {
-      "query": [
-        "id",
-        "client_id"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/tenants/azure/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "status",
-        "limit",
-        "offset"
-      ]
-    }
-  },
-  "/kubernetes-protection/entities/user-script/azure/v1": {
-    "get": {
-      "query": [
-        "id",
-        "subscription_id"
-      ]
-    }
-  },
-  "/loggingapi/combined/repos/v1": {
-    "get": {
-      "query": [
-        "check_test_data"
-      ]
-    }
-  },
-  "/loggingapi/entities/saved-searches/execute/v1": {
-    "get": {
-      "query": [
-        "job_id",
-        "app_id",
-        "infer_json_types",
-        "job_status_only",
-        "limit",
-        "match_response_schema",
-        "metadata",
-        "offset"
-      ]
-    }
-  },
-  "/loggingapi/entities/views/v1": {
-    "get": {
-      "query": [
-        "check_test_data"
-      ]
-    }
-  },
-  "/malquery/aggregates/quotas/v1": {
-    "get": {}
-  },
-  "/malquery/entities/download-files/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/malquery/entities/metadata/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/malquery/entities/requests/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/malquery/entities/samples-multidownload/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "samples"
-        ]
-      }
-    }
-  },
-  "/message-center/entities/case-activities/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/message-center/entities/case-activity/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "body",
-          "case_id",
-          "type",
-          "user_uuid"
-        ]
-      }
-    }
-  },
-  "/message-center/entities/case-attachment/v1": {
-    "get": {
-      "query": [
-        "id"
-      ]
-    },
-    "post": {
-      "formdata": [
-        "case_id",
-        "user_uuid",
-        "file"
-      ]
-    }
-  },
-  "/message-center/entities/cases/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/message-center/queries/case-activities/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset",
-        "case_id"
-      ]
-    }
-  },
-  "/message-center/queries/cases/v1": {
-    "get": {
-      "query": [
-        "limit",
-        "sort",
-        "filter",
-        "offset"
-      ]
-    }
-  },
-  "/mssp/entities/children/GET/v2": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/cid-group-members/v1": {
-    "post": {
-      "body": {
-        "resources": [
-          "cid_group_id",
-          "cids"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/cid-group-members/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "delete": {
-      "body": {
-        "resources": [
-          "cid_group_id",
-          "cids"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/cid-groups/v1": {
-    "post": {
-      "body": {
-        "resources": [
-          "cid",
-          "cid_group_id",
-          "description",
-          "is_default",
-          "name"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "cid_group_ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "cid",
-          "cid_group_id",
-          "description",
-          "is_default",
-          "name"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/cid-groups/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/mssp/entities/mssp-roles/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "cid_group_id",
-          "id",
-          "role_ids",
-          "user_group_id"
-        ]
-      }
-    },
-    "delete": {
-      "body": {
-        "resources": [
-          "cid_group_id",
-          "id",
-          "role_ids",
-          "user_group_id"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/user-group-members/v1": {
-    "post": {
-      "body": {
-        "resources": [
-          "user_group_id",
-          "user_uuids"
-        ]
-      }
-    },
-    "delete": {
-      "body": {
-        "resources": [
-          "user_group_id",
-          "user_uuids"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/user-group-members/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/mssp/entities/user-groups/v1": {
-    "post": {
-      "body": {
-        "resources": [
-          "cid",
-          "description",
-          "name",
-          "user_group_id"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "user_group_ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "cid",
-          "description",
-          "name",
-          "user_group_id"
-        ]
-      }
-    }
-  },
-  "/mssp/entities/user-groups/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/mssp/queries/children/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/mssp/queries/cid-group-members/v1": {
-    "get": {
-      "query": [
-        "cid",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/mssp/queries/cid-groups/v1": {
-    "get": {
-      "query": [
-        "name",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/mssp/queries/mssp-roles/v1": {
-    "get": {
-      "query": [
-        "user_group_id",
-        "cid_group_id",
-        "role_id",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/mssp/queries/user-group-members/v1": {
-    "get": {
-      "query": [
-        "user_uuid",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/mssp/queries/user-groups/v1": {
-    "get": {
-      "query": [
-        "name",
-        "sort",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/ods/entities/malicious-files/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ods/entities/scan-control-actions/cancel/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/ods/entities/scan-hosts/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ods/entities/scans/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "cloud_ml_level_detection",
-          "cloud_ml_level_prevention",
-          "cpu_priority",
-          "description",
-          "endpoint_notification",
-          "file_paths",
-          "host_groups",
-          "hosts",
-          "initiated_from",
-          "max_duration",
-          "pause_duration",
-          "quarantine",
-          "scan_exclusions",
-          "scan_inclusions",
-          "sensor_ml_level_detection",
-          "sensor_ml_level_prevention"
-        ]
-      }
-    }
-  },
-  "/ods/entities/scans/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ods/entities/scheduled-scans/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/ods/queries/malicious-files/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/ods/queries/scan-hosts/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/ods/queries/scans/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/ods/queries/scheduled-scans/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/overwatch-dashboards/aggregates/detections-global-counts/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/overwatch-dashboards/aggregates/incidents-global-counts/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/overwatch-dashboards/aggregates/ow-events-global-counts/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/plugins/combined/configs/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/content-update/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/content-update-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/device-control-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/device-control/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/firewall-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/firewall/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/prevention-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/prevention/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/response-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/response/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/reveal-uninstall-token/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "audit_message",
-          "device_id"
-        ]
-      }
-    }
-  },
-  "/policy/combined/sensor-update-builds/v1": {
-    "get": {
-      "query": [
-        "platform",
-        "stage"
-      ]
-    }
-  },
-  "/policy/combined/sensor-update-kernels/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/policy/combined/sensor-update-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/combined/sensor-update/v2": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/entities/content-update/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "description",
-          "id",
-          "name",
-          "settings"
-        ]
-      }
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "description",
-          "name",
-          "settings"
-        ]
-      }
-    }
-  },
-  "/policy/entities/content-update-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/policy/entities/default-device-control/v1": {
-    "get": {},
-    "patch": {
-      "body": {
-        "custom_notifications": [
-          "blocked_notification",
-          "restricted_notification"
-        ]
-      }
-    }
-  },
-  "/policy/entities/device-control-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids",
-          "platform_name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/device-control/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "clone_id",
-          "description",
-          "name",
-          "platform_name",
-          "settings"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "description",
-          "id",
-          "name",
-          "settings"
-        ]
-      }
-    }
-  },
-  "/policy/entities/firewall-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids",
-          "platform_name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/firewall/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "clone_id",
-          "description",
-          "name",
-          "platform_name"
-        ]
-      },
-      "query": [
-        "clone_id"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "description",
-          "id",
-          "name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/ioa-exclusions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "cl_regex",
-          "comment",
-          "description",
-          "detection_json",
-          "groups",
-          "ifn_regex",
-          "name",
-          "pattern_id",
-          "pattern_name"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "comment"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "cl_regex",
-          "comment",
-          "description",
-          "detection_json",
-          "groups",
-          "id",
-          "ifn_regex",
-          "name",
-          "pattern_id",
-          "pattern_name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/ml-exclusions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "comment",
-          "excluded_from",
-          "groups",
-          "value"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "comment"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "comment",
-          "groups",
-          "id",
-          "is_descendant_process",
-          "value"
-        ]
-      }
-    }
-  },
-  "/policy/entities/prevention-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids",
-          "platform_name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/prevention/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "clone_id",
-          "description",
-          "name",
-          "platform_name",
-          "settings"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "description",
-          "id",
-          "name",
-          "settings"
-        ]
-      }
-    }
-  },
-  "/policy/entities/response-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids",
-          "platform_name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/response/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "clone_id",
-          "description",
-          "name",
-          "platform_name",
-          "settings"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "description",
-          "id",
-          "name",
-          "settings"
-        ]
-      }
-    }
-  },
-  "/policy/entities/sensor-update-precedence/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids",
-          "platform_name"
-        ]
-      }
-    }
-  },
-  "/policy/entities/sensor-update/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/policy/entities/sensor-update/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "description",
-          "name",
-          "platform_name",
-          "settings"
-        ]
-      }
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "description",
-          "id",
-          "name",
-          "settings"
-        ]
-      }
-    }
-  },
-  "/policy/entities/sv-exclusions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "comment",
-          "groups",
-          "is_descendant_process",
-          "value"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "comment"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "comment",
-          "groups",
-          "id",
-          "is_descendant_process",
-          "value"
-        ]
-      }
-    }
-  },
-  "/policy/queries/content-update/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/content-update-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/device-control-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/device-control/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/firewall-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/firewall/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/ioa-exclusions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "ifn_regex",
-        "cl_regex",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/ml-exclusions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/prevention-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/prevention/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/response-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/response/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/sensor-update-kernels/{distinct-field}/v1": {
-    "get": {
-      "query": [
-        "distinct-field",
-        "filter",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/policy/queries/sensor-update-members/v1": {
-    "get": {
-      "query": [
-        "id",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/sensor-update/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/policy/queries/sv-exclusions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/processes/entities/processes/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/quarantine/aggregates/action-update-count/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/quarantine/entities/quarantined-files/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/quarantine/entities/quarantined-files/v1": {
-    "patch": {
-      "body": {
-        "root": [
-          "action",
-          "comment",
-          "ids"
-        ]
-      }
-    }
-  },
-  "/quarantine/queries/quarantined-files/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "action",
-          "comment",
-          "filter",
-          "q"
-        ]
-      }
-    }
-  },
-  "/quickscanpro/entities/files/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "formdata": [
-        "file",
-        "scan"
-      ]
-    }
-  },
-  "/quickscanpro/entities/scans/v1": {
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "sha256"
-        ]
-      }
-    }
-  },
-  "/quickscanpro/queries/scans/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/real-time-response-audit/combined/sessions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "sort",
-        "limit",
-        "offset",
-        "with_command_info"
-      ]
-    }
-  },
-  "/real-time-response/combined/batch-active-responder-command/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "base_command",
-          "batch_id",
-          "command_string",
-          "optional_hosts",
-          "persist_all"
-        ]
-      },
-      "query": [
-        "timeout",
-        "timeout_duration",
-        "host_timeout_duration"
-      ]
-    }
-  },
-  "/real-time-response/combined/batch-command/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "base_command",
-          "batch_id",
-          "command_string",
-          "optional_hosts",
-          "persist_all"
-        ]
-      },
-      "query": [
-        "timeout",
-        "timeout_duration",
-        "host_timeout_duration"
-      ]
-    }
-  },
-  "/real-time-response/combined/batch-get-command/v1": {
-    "get": {
-      "query": [
-        "timeout",
-        "timeout_duration",
-        "batch_get_cmd_req_id"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "batch_id",
-          "file_path",
-          "optional_hosts"
-        ]
-      },
-      "query": [
-        "timeout",
-        "timeout_duration",
-        "host_timeout_duration"
-      ]
-    }
-  },
-  "/real-time-response/combined/batch-init-session/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "existing_batch_id",
-          "host_ids",
-          "queue_offline"
-        ]
-      },
-      "query": [
-        "timeout",
-        "timeout_duration",
-        "host_timeout_duration"
-      ]
-    }
-  },
-  "/real-time-response/combined/batch-refresh-session/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "batch_id",
-          "hosts_to_remove"
-        ]
-      },
-      "query": [
-        "timeout",
-        "timeout_duration"
-      ]
-    }
-  },
-  "/real-time-response/entities/active-responder-command/v1": {
-    "get": {
-      "query": [
-        "cloud_request_id",
-        "sequence_id"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "base_command",
-          "command_string",
-          "device_id",
-          "id",
-          "persist",
-          "session_id"
-        ]
-      }
-    }
-  },
-  "/real-time-response/entities/admin-command/v1": {
-    "get": {
-      "query": [
-        "cloud_request_id",
-        "sequence_id"
-      ]
-    }
-  },
-  "/real-time-response/entities/command/v1": {
-    "get": {
-      "query": [
-        "cloud_request_id",
-        "sequence_id"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "base_command",
-          "command_string",
-          "device_id",
-          "id",
-          "persist",
-          "session_id"
-        ]
-      }
-    }
-  },
-  "/real-time-response/entities/extracted-file-contents/v1": {
-    "get": {
-      "query": [
-        "session_id",
-        "sha256",
-        "filename"
-      ]
-    }
-  },
-  "/real-time-response/entities/falcon-scripts/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/real-time-response/entities/file/v2": {
-    "get": {
-      "query": [
-        "session_id"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "session_id"
-      ]
-    }
-  },
-  "/real-time-response/entities/put-files/v1": {
-    "post": {
-      "formdata": [
-        "file",
-        "description",
-        "name",
-        "comments_for_audit_log"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/real-time-response/entities/put-files/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/real-time-response/entities/queued-sessions/command/v1": {
-    "delete": {
-      "query": [
-        "session_id",
-        "cloud_request_id"
-      ]
-    }
-  },
-  "/real-time-response/entities/queued-sessions/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/real-time-response/entities/refresh-session/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "device_id",
-          "origin",
-          "queue_offline"
-        ]
-      }
-    }
-  },
-  "/real-time-response/entities/scripts/v1": {
-    "post": {
-      "formdata": [
-        "file",
-        "description",
-        "name",
-        "comments_for_audit_log",
-        "permission_type",
-        "content",
-        "platform"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "formdata": [
-        "id",
-        "file",
-        "description",
-        "name",
-        "comments_for_audit_log",
-        "permission_type",
-        "content",
-        "platform"
-      ]
-    }
-  },
-  "/real-time-response/entities/scripts/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/real-time-response/entities/sessions/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/real-time-response/entities/sessions/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "device_id",
-          "origin",
-          "queue_offline"
-        ]
-      },
-      "query": [
-        "timeout",
-        "timeout_duration"
-      ]
-    },
-    "delete": {
-      "query": [
-        "session_id"
-      ]
-    }
-  },
-  "/real-time-response/queries/falcon-scripts/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/real-time-response/queries/put-files/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/real-time-response/queries/scripts/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/real-time-response/queries/sessions/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/recon/aggregates/rules-preview/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "filter",
-          "topic"
-        ]
-      }
-    }
-  },
-  "/recon/entities/actions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "actions": [
-          "content_format",
-          "frequency",
-          "recipients",
-          "trigger_matchless",
-          "type"
-        ],
-        "root": [
-          "rule_id"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "id"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "content_format",
-          "frequency",
-          "id",
-          "recipients",
-          "status",
-          "trigger_matchless"
-        ]
-      }
-    }
-  },
-  "/recon/entities/export-files/v1": {
-    "get": {
-      "query": [
-        "id"
-      ]
-    }
-  },
-  "/recon/entities/exports/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "entity",
-          "export_type",
-          "filter",
-          "human_readable",
-          "sort"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/recon/entities/notifications-detailed-translated/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/recon/entities/notifications-detailed/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/recon/entities/notifications-exposed-data-records/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/recon/entities/notifications-translated/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/recon/entities/notifications/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "assigned_to_uuid",
-          "id",
-          "idp_send_status",
-          "message",
-          "status"
-        ]
-      }
-    }
-  },
-  "/recon/entities/rules/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "root": [
-          "breach_monitor_only",
-          "breach_monitoring_enabled",
-          "filter",
-          "match_on_tsq_result_types",
-          "name",
-          "originating_template_id",
-          "permissions",
-          "priority",
-          "substring_matching_enabled",
-          "topic"
-        ]
-      }
-    },
-    "delete": {
-      "query": [
-        "ids",
-        "notificationsDeletionRequested"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "breach_monitor_only",
-          "breach_monitoring_enabled",
-          "filter",
-          "id",
-          "match_on_tsq_result_types",
-          "name",
-          "permissions",
-          "priority",
-          "substring_matching_enabled"
-        ]
-      }
-    }
-  },
-  "/recon/queries/actions/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/recon/queries/notifications-exposed-data-records/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/recon/queries/notifications/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/recon/queries/rules/v1": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q",
-        "secondarySort"
-      ]
-    }
-  },
-  "/reports/entities/report-executions-download/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/reports/entities/report-executions/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/reports/entities/scheduled-reports/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/reports/queries/report-executions/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/reports/queries/scheduled-reports/v1": {
-    "get": {
-      "query": [
-        "sort",
-        "filter",
-        "q",
-        "offset",
-        "limit"
-      ]
-    }
-  },
-  "/samples/entities/samples/v3": {
-    "get": {
-      "query": [
-        "ids",
-        "password_protected"
-      ]
-    },
-    "delete": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/samples/queries/samples/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "sha256s"
-        ]
-      }
-    }
-  },
-  "/sensors/combined/installers/v2": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/sensors/entities/datafeed-actions/v1/{partition}": {
-    "post": {
-      "query": [
-        "action_name",
-        "appId",
-        "partition"
-      ]
-    }
-  },
-  "/sensors/entities/datafeed/v2": {
-    "get": {
-      "query": [
-        "appId",
-        "format"
-      ]
-    }
-  },
-  "/sensors/entities/download-installer/v2": {
-    "get": {
-      "query": [
-        "id"
-      ]
-    }
-  },
-  "/sensors/entities/installers/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/sensors/queries/installers/v2": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/settings/entities/policy-details/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/settings/entities/policy/v1": {
-    "get": {
-      "query": [
-        "service",
-        "policy-id",
-        "cloud-platform"
-      ]
-    },
-    "patch": {
-      "body": {
-        "resources": [
-          "account_id",
-          "account_ids",
-          "enabled",
-          "policy_id",
-          "regions",
-          "severity",
-          "tag_excluded"
-        ]
-      }
-    }
-  },
-  "/settings/scan-schedule/v1": {
-    "get": {
-      "query": [
-        "cloud-platform"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "cloud_platform",
-          "next_scan_timestamp",
-          "scan_interval",
-          "scan_schedule"
-        ]
-      }
-    }
-  },
-  "/snapshots/combined/deployments/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "offset",
-        "sort"
-      ]
-    }
-  },
-  "/snapshots/entities/accounts/v1": {
-    "post": {
-      "body": {
-        "aws_accounts": [
-          "account_number",
-          "batch_regions",
-          "iam_external_id",
-          "iam_role_arn",
-          "kms_alias",
-          "processing_account"
-        ]
-      }
-    }
-  },
-  "/snapshots/entities/deployments/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    },
-    "post": {
-      "body": {
-        "resources": [
-          "account_id",
-          "asset_identifier",
-          "cloud_provider",
-          "region"
-        ]
-      }
-    }
-  },
-  "/snapshots/entities/scanreports/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/spotlight/combined/evaluation-logic/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "filter",
-        "sort"
-      ]
-    }
-  },
-  "/spotlight/combined/vulnerabilities/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter",
-        "facet"
-      ]
-    }
-  },
-  "/spotlight/entities/evaluation-logic/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/spotlight/entities/remediations/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/spotlight/entities/vulnerabilities/v2": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/spotlight/queries/evaluation-logic/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "filter",
-        "sort"
-      ]
-    }
-  },
-  "/spotlight/queries/vulnerabilities/v1": {
-    "get": {
-      "query": [
-        "after",
-        "limit",
-        "sort",
-        "filter"
-      ]
-    }
-  },
-  "/threatgraph/combined/{vertex-type}/summary/v1": {
-    "get": {
-      "query": [
-        "vertex-type",
-        "ids",
-        "scope",
-        "nano"
-      ]
-    }
-  },
-  "/threatgraph/combined/edges/v1": {
-    "get": {
-      "query": [
-        "ids",
-        "limit",
-        "offset",
-        "edge_type",
-        "direction",
-        "scope",
-        "nano"
-      ]
-    }
-  },
-  "/threatgraph/combined/ran-on/v1": {
-    "get": {
-      "query": [
-        "value",
-        "type",
-        "limit",
-        "offset",
-        "nano"
-      ]
-    }
-  },
-  "/threatgraph/entities/{vertex-type}/v2": {
-    "get": {
-      "query": [
-        "vertex-type",
-        "ids",
-        "scope",
-        "nano"
-      ]
-    }
-  },
-  "/threatgraph/queries/edge-types/v1": {
-    "get": {}
-  },
-  "/ti/events/entities/events/GET/v2": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/ti/events/queries/events/v2": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/ti/rules/entities/rules/GET/v2": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/ti/rules/queries/rules/v2": {
-    "get": {
-      "query": [
-        "offset",
-        "limit",
-        "sort",
-        "filter",
-        "q"
-      ]
-    }
-  },
-  "/user-management/combined/user-roles/v1": {
-    "get": {
-      "query": [
-        "user_uuid",
-        "cid",
-        "direct_only",
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/user-management/entities/roles/v1": {
-    "get": {
-      "query": [
-        "cid",
-        "ids"
-      ]
-    }
-  },
-  "/user-management/entities/user-role-actions/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "action",
-          "cid",
-          "role_ids",
-          "uuid"
-        ]
-      }
-    }
-  },
-  "/user-management/entities/users/GET/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      }
-    }
-  },
-  "/user-management/entities/users/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "cid",
-          "first_name",
-          "last_name",
-          "password",
-          "uid"
-        ]
-      },
-      "query": [
-        "validate_only"
-      ]
-    },
-    "delete": {
-      "query": [
-        "user_uuid"
-      ]
-    },
-    "patch": {
-      "body": {
-        "root": [
-          "first_name",
-          "last_name"
-        ]
-      },
-      "query": [
-        "user_uuid"
-      ]
-    }
-  },
-  "/user-management/queries/roles/v1": {
-    "get": {
-      "query": [
-        "cid",
-        "user_uuid",
-        "action"
-      ]
-    }
-  },
-  "/user-management/queries/users/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/workflows/combined/activities/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/workflows/combined/definitions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/workflows/combined/executions/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "offset",
-        "limit",
-        "sort"
-      ]
-    }
-  },
-  "/workflows/combined/triggers/v1": {
-    "get": {
-      "query": [
-        "filter"
-      ]
-    }
-  },
-  "/workflows/entities/definitions/export/v1": {
-    "get": {
-      "query": [
-        "id",
-        "sanitize"
-      ]
-    }
-  },
-  "/workflows/entities/definitions/import/v1": {
-    "post": {
-      "formdata": [
-        "data_file",
-        "name",
-        "validate_only"
-      ]
-    }
-  },
-  "/workflows/entities/execute/v1": {
-    "post": {
-      "body": {
-        "root": []
-      },
-      "query": [
-        "execution_cid",
-        "definition_id",
-        "name",
-        "key",
-        "depth",
-        "source_event_url"
-      ]
-    }
-  },
-  "/workflows/entities/execution-actions/v1": {
-    "post": {
-      "body": {
-        "root": [
-          "ids"
-        ]
-      },
-      "query": [
-        "action_name"
-      ]
-    }
-  },
-  "/workflows/entities/execution-results/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/workflows/entities/human-inputs/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/zero-trust-assessment/entities/assessments/v1": {
-    "get": {
-      "query": [
-        "ids"
-      ]
-    }
-  },
-  "/zero-trust-assessment/queries/assessments/v1": {
-    "get": {
-      "query": [
-        "filter",
-        "limit",
-        "after",
-        "sort"
-      ]
-    }
-  }
 }

--- a/public/user-management.ps1
+++ b/public/user-management.ps1
@@ -10,7 +10,7 @@ User identifier
 Customer identifier
 .PARAMETER Id
 User role
-.PARAMETER expires_at
+.PARAMETER ExpiresAt
 Expiration date
 .LINK
 https://github.com/crowdstrike/psfalcon/wiki/Add-FalconRole
@@ -32,8 +32,8 @@ https://github.com/crowdstrike/psfalcon/wiki/Add-FalconRole
     [string[]]$Id,
     [Parameter(ParameterSetName='/user-management/entities/user-role-actions/v1:post',Position=4)]
     [ValidatePattern('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T(00|[0-9]|1[0-9]|2[0-3]):([0-9]|[0-5][0-9]):([0-9]|[0-5][0-9])Z')]
-    [Alias('date','expiration')]
-    [string]$expires_at
+    [Alias('expires_at','date','expiration')]
+    [string]$ExpiresAt
   )
   begin {
     $Param = @{ Command = $MyInvocation.MyCommand.Name; Endpoint = $PSCmdlet.ParameterSetName }
@@ -46,7 +46,7 @@ https://github.com/crowdstrike/psfalcon/wiki/Add-FalconRole
       $PSBoundParameters['role_ids'] = @($List)
       $PSBoundParameters['uuid'] = $PSBoundParameters.UserId
       $PSBoundParameters['action'] = 'grant'
-      $PSBoundParameters['expires_at'] = $PSBoundParameters.expires_at
+      $PSBoundParameters['expires_at'] = $PSBoundParameters.ExpiresAt
       [void]$PSBoundParameters.Remove('Id')
       [void]$PSBoundParameters.Remove('UserId')
       Invoke-Falcon @Param -UserInput $PSBoundParameters

--- a/public/user-management.ps1
+++ b/public/user-management.ps1
@@ -10,6 +10,8 @@ User identifier
 Customer identifier
 .PARAMETER Id
 User role
+.PARAMETER expires_at
+Expiration date
 .LINK
 https://github.com/crowdstrike/psfalcon/wiki/Add-FalconRole
 #>
@@ -27,7 +29,11 @@ https://github.com/crowdstrike/psfalcon/wiki/Add-FalconRole
     [string]$Cid,
     [Parameter(ParameterSetName='/user-management/entities/user-role-actions/v1:post',Mandatory,Position=3)]
     [Alias('role_ids','ids')]
-    [string[]]$Id
+    [string[]]$Id,
+    [Parameter(ParameterSetName='/user-management/entities/user-role-actions/v1:post',Position=4)]
+    [ValidatePattern('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T(00|[0-9]|1[0-9]|2[0-3]):([0-9]|[0-5][0-9]):([0-9]|[0-5][0-9])Z')]
+    [Alias('date','expiration')]
+    [string]$expires_at
   )
   begin {
     $Param = @{ Command = $MyInvocation.MyCommand.Name; Endpoint = $PSCmdlet.ParameterSetName }
@@ -40,6 +46,7 @@ https://github.com/crowdstrike/psfalcon/wiki/Add-FalconRole
       $PSBoundParameters['role_ids'] = @($List)
       $PSBoundParameters['uuid'] = $PSBoundParameters.UserId
       $PSBoundParameters['action'] = 'grant'
+      $PSBoundParameters['expires_at'] = $PSBoundParameters.expires_at
       [void]$PSBoundParameters.Remove('Id')
       [void]$PSBoundParameters.Remove('UserId')
       Invoke-Falcon @Param -UserInput $PSBoundParameters


### PR DESCRIPTION
## Added features and functionality

Since may 22, API /user-management/entities/user-role-actions/v1 supports temporary roles (https://supportportal.crowdstrike.com/s/article/Release-Notes-Falcon-Administrator-Temporary-Role-Grants).
This pull requests add the "expires_at" field in the module Add-FalconRole.

## Other
TODO : 
expiration date is not checked before calling API, needs to be from 1 hour to 7 days from now only.
Update wiki (https://github.com/CrowdStrike/psfalcon/wiki/Add-FalconRole) to add the new parameter